### PR TITLE
wpewebkit: fix two compilation issues

### DIFF
--- a/package/cairo/0007-cairo-egl-device-create-for-egl-surface.patch
+++ b/package/cairo/0007-cairo-egl-device-create-for-egl-surface.patch
@@ -1,0 +1,133 @@
+From a4e0daf18bf8252463f66d75eef499cfffa32565 Mon Sep 17 00:00:00 2001
+From: Zan Dobersek <zdobersek@igalia.com>
+Date: Mon, 17 Nov 2014 01:23:15 -0800
+Subject: [PATCH] Add cairo_egl_device_create_for_egl_surface().
+
+---
+ src/cairo-egl-context.c | 66 ++++++++++++++++++++++++++++++++++++++++++-------
+ src/cairo-gl.h          |  3 +++
+ 2 files changed, 60 insertions(+), 9 deletions(-)
+
+diff --git a/src/cairo-egl-context.c b/src/cairo-egl-context.c
+index bf704c6..be2bcf9 100644
+--- a/src/cairo-egl-context.c
++++ b/src/cairo-egl-context.c
+@@ -48,7 +48,8 @@ typedef struct _cairo_egl_context {
+     EGLDisplay display;
+     EGLContext context;
+ 
+-    EGLSurface dummy_surface;
++    EGLSurface surface;
++    cairo_bool_t is_dummy_surface;
+ 
+     EGLContext previous_context;
+     EGLSurface previous_surface;
+@@ -74,7 +75,7 @@ _egl_get_current_surface (cairo_egl_context_t *ctx)
+ {
+     if (ctx->base.current_target == NULL ||
+         _cairo_gl_surface_is_texture (ctx->base.current_target)) {
+-	return  ctx->dummy_surface;
++	return  ctx->surface;
+     }
+ 
+     return ((cairo_egl_surface_t *) ctx->base.current_target)->egl;
+@@ -151,8 +152,8 @@ _egl_destroy (void *abstract_ctx)
+ 
+     eglMakeCurrent (ctx->display,
+ 		    EGL_NO_SURFACE, EGL_NO_SURFACE, EGL_NO_CONTEXT);
+-    if (ctx->dummy_surface != EGL_NO_SURFACE)
+-        eglDestroySurface (ctx->display, ctx->dummy_surface);
++    if (ctx->is_dummy_surface && ctx->surface != EGL_NO_SURFACE)
++        eglDestroySurface (ctx->display, ctx->surface);
+ }
+ 
+ static cairo_bool_t
+@@ -218,13 +219,14 @@ cairo_egl_device_create (EGLDisplay dpy, EGLContext egl)
+ 	eglQueryContext (dpy, egl, EGL_CONFIG_ID, &config_attribs[1]);
+ 	eglChooseConfig (dpy, config_attribs, &config, 1, &numConfigs);
+ 
+-	ctx->dummy_surface = eglCreatePbufferSurface (dpy, config, attribs);
+-	if (ctx->dummy_surface == NULL) {
++	ctx->is_dummy_surface = TRUE;
++	ctx->surface = eglCreatePbufferSurface (dpy, config, attribs);
++	if (ctx->surface == NULL) {
+ 	    free (ctx);
+ 	    return _cairo_gl_context_create_in_error (CAIRO_STATUS_NO_MEMORY);
+ 	}
+ 
+-	if (!eglMakeCurrent (dpy, ctx->dummy_surface, ctx->dummy_surface, egl)) {
++	if (!eglMakeCurrent (dpy, ctx->surface, ctx->surface, egl)) {
+ 	    free (ctx);
+ 	    return _cairo_gl_context_create_in_error (CAIRO_STATUS_NO_MEMORY);
+ 	}
+@@ -238,8 +240,54 @@ cairo_egl_device_create (EGLDisplay dpy, EGLContext egl)
+ 
+     status = _cairo_gl_context_init (&ctx->base);
+     if (unlikely (status)) {
+-	if (ctx->dummy_surface != EGL_NO_SURFACE)
+-	    eglDestroySurface (dpy, ctx->dummy_surface);
++	if (ctx->surface != EGL_NO_SURFACE)
++	    eglDestroySurface (dpy, ctx->surface);
++	free (ctx);
++	return _cairo_gl_context_create_in_error (status);
++    }
++
++    eglMakeCurrent (dpy, EGL_NO_SURFACE, EGL_NO_SURFACE, EGL_NO_CONTEXT);
++
++    return &ctx->base.base;
++}
++
++cairo_device_t *
++cairo_egl_device_create_for_egl_surface (EGLDisplay dpy, EGLContext egl, EGLSurface surface)
++{
++    cairo_egl_context_t *ctx;
++    cairo_status_t status;
++
++    ctx = calloc (1, sizeof (cairo_egl_context_t));
++    if (unlikely (ctx == NULL))
++	return _cairo_gl_context_create_in_error (CAIRO_STATUS_NO_MEMORY);
++
++    ctx->display = dpy;
++    ctx->context = egl;
++    ctx->surface = surface;
++
++    ctx->base.acquire = _egl_acquire;
++    ctx->base.release = _egl_release;
++    ctx->base.make_current = _egl_make_current;
++    ctx->base.swap_buffers = _egl_swap_buffers;
++    ctx->base.destroy = _egl_destroy;
++
++    /* We are about the change the current state of EGL, so we should
++     * query the pre-existing surface now instead of later. */
++    _egl_query_current_state (ctx);
++
++	if (!eglMakeCurrent (dpy, surface, surface, egl)) {
++	    free (ctx);
++	    return _cairo_gl_context_create_in_error (CAIRO_STATUS_NO_MEMORY);
++	}
++
++    status = _cairo_gl_dispatch_init (&ctx->base.dispatch, eglGetProcAddress);
++    if (unlikely (status)) {
++	free (ctx);
++	return _cairo_gl_context_create_in_error (status);
++    }
++
++    status = _cairo_gl_context_init (&ctx->base);
++    if (unlikely (status)) {
+ 	free (ctx);
+ 	return _cairo_gl_context_create_in_error (status);
+     }
+diff --git a/src/cairo-gl.h b/src/cairo-gl.h
+index 9fd7608..a94f581 100644
+--- a/src/cairo-gl.h
++++ b/src/cairo-gl.h
+@@ -132,6 +132,9 @@ cairo_gl_surface_create_for_dc (cairo_device_t		*device,
+ cairo_public cairo_device_t *
+ cairo_egl_device_create (EGLDisplay dpy, EGLContext egl);
+ 
++cairo_public cairo_device_t *
++cairo_egl_device_create_for_egl_surface (EGLDisplay dpy, EGLContext egl, EGLSurface surface);
++
+ cairo_public cairo_surface_t *
+ cairo_gl_surface_create_for_egl (cairo_device_t	*device,
+ 				 EGLSurface	 egl,

--- a/package/wpe/wpewebkit/0001-webp-support-wip.patch
+++ b/package/wpe/wpewebkit/0001-webp-support-wip.patch
@@ -64,7 +64,10 @@ index 4a38f58..4f07e36 100644
 +{
 +    if (index >= frameCount())
 +        return 0;
-+
+ 
+-    ImageFrame& frame = m_frameBufferCache[0];
+-    if (!frame.isComplete())
+-        decode(false);
 +    ImageFrame& frame = m_frameBufferCache[index];
 +    if (frame.isComplete())
 +        return &frame;
@@ -75,10 +78,7 @@ index 4a38f58..4f07e36 100644
 +        framesToDecode.append(frameToDecode);
 +        while (frameToDecode > 0 && !m_frameBufferCache[frameToDecode - 1].isComplete())
 +            framesToDecode.append(--frameToDecode);
- 
--    ImageFrame& frame = m_frameBufferCache[0];
--    if (!frame.isComplete())
--        decode(false);
++
 +        //do {
 +            // see Chromium commit 6e5bde615781b310f8e6f03bc4e81b6a5f993bf2
 +            //frameToDecode = m_frameBufferCache[frameToDecode].requiredPreviousFrameIndex();
@@ -226,7 +226,7 @@ index 4a38f58..4f07e36 100644
 +        } else {
 +            // FIXME: use this: const ImageFrame& prevBuffer = m_frameBufferCache[requiredPreviousFrameIndex];
 +            const ImageFrame& prevBuffer = m_frameBufferCache[frameIndex - 1];
-+            ASSERT(prevBuffer.status() == ImageFrame::FrameComplete);
++            ASSERT(prevBuffer.isComplete());
 +
 +            // Preserve the last frame as the starting state for this frame.
 +            if (!prevBuffer.backingStore() || !buffer.initialize(*prevBuffer.backingStore()))
@@ -284,7 +284,7 @@ index 4a38f58..4f07e36 100644
 +        ImageFrame& prevBuffer = m_frameBufferCache[frameIndex - 1];
 +        ImageFrame::DisposalMethod prevMethod = prevBuffer.disposalMethod();
 +        if (prevMethod == ImageFrame::DisposalMethod::RestoreToPrevious) { // Restore transparent pixels to pixels in previous canvas.
-+            ASSERT(prevBuffer.status() == ImageFrame::FrameComplete);
++            ASSERT(prevBuffer.isComplete());
 +            for (int y = m_decodedHeight; y < decodedHeight; ++y) {
 +                const int canvasY = top + y;
 +                for (int x = 0; x < width; ++x) {
@@ -301,7 +301,7 @@ index 4a38f58..4f07e36 100644
 +        } else if (prevMethod == ImageFrame::DisposalMethod::RestoreToBackground && frameIndex != 0) {
 +            // FIXME: check above should be: buffer.requiredPreviousFrameIndex() != notFound
 +            // Note: if the requiredPreviousFrameIndex is |notFound|, there's nothing to do.
-+            ASSERT(prevBuffer.status() == ImageFrame::FrameComplete);
++            ASSERT(prevBuffer.isComplete());
 +            const IntRect& prevRect = prevBuffer.backingStore()->frameRect();
 +            // We need to restore transparent pixels to as they were just after initFrame() call. That is:
 +            //   * Transparent if it belongs to prevRect <-- This is a no-op.
@@ -435,11 +435,12 @@ index e282b22..f6b155d7 100644
  
      WebPIDecoder* m_decoder;
 -    bool m_hasAlpha;
+-
+-    void applyColorProfile(const uint8_t*, size_t, ImageFrame&) { };
 +    WebPDecBuffer m_decoderBuffer;
 +    int m_formatFlags;
 +    bool m_frameBackgroundHasAlpha;
- 
--    void applyColorProfile(const uint8_t*, size_t, ImageFrame&) { };
++
 +    WebPDemuxer* m_demux;
 +    WebPDemuxState m_demuxState;
 +    bool m_haveAlreadyParsedThisData;


### PR DESCRIPTION
Got a couple of compilation issues in the wpewebkit package using this buildroot to compile an image for an board with Freedreno driver, using the WAYLAND_EGL backend.

In first place, this error:
```
platform/image-decoders/webp/WEBPImageDecoder.cpp:264:31: error: 'const class WebCore::ImageFrame' has no member named 'status'
             ASSERT(prevBuffer.status() == ImageFrame::FrameComplete);
                               ^
```

The status member does not exist any more in ImageFrame class. Instead, there are several isXXX() methods that can be used. I replaced any use of status with the corresponding isXXX() function in
the downstream patch for WEBPImageDecoder.

In second place:
```
platform/graphics/egl/GLContextEGL.cpp: In member function 'virtual cairo_device_t* WebCore::GLContextEGL::cairoDevice()':
platform/graphics/egl/GLContextEGL.cpp:313:105: error: 'cairo_egl_device_create_for_egl_surface' was not declared in this scope
     m_cairoDevice = cairo_egl_device_create_for_egl_surface(m_display.eglDisplay(), m_context, m_surface);
                                                                                                         ^
```

The missing symbol is added by a cairo patch that is included by jhbuild in a desktop WPEWebKit build. Included that patch in the buildroot project.