### PR TITLE
Fix commit id for gst-omx snapshot version

### DIFF
--- a/package/gstreamer1/gst-omx/gst-omx.mk
+++ b/package/gstreamer1/gst-omx/gst-omx.mk
@@ -9,7 +9,7 @@ GST_OMX_SOURCE = gst-omx-$(GST_OMX_VERSION).tar.xz
 GST_OMX_SITE = https://gstreamer.freedesktop.org/src/gst-omx
 
 ifeq ($(BR2_PACKAGE_GSTREAMER1_GIT),y)
-GST_OMX_VERSION = 98df98e65b4035792557a76d21897fd953875bca
+GST_OMX_VERSION = 70ad93c2db85c123ac9ddbd051749f7425a90bf5
 GST_OMX_SOURCE = gst-omx-$(GST_OMX_VERSION).tar.xz
 GST_OMX_SITE = http://cgit.freedesktop.org/gstreamer/gst-omx/snapshot
 BR_NO_CHECK_HASH_FOR += $(GST_OMX_SOURCE)


### PR DESCRIPTION
Changed commit id in makefile to point to the 1.10.4 snapshot and match the version of the src tarball. Current commit id points to 1.10.2

I've yet to test whether the existing patches apply.