### PR TITLE
[gstreamer] Add patches for parsing key ids out of mss manifests.

### DIFF
--- a/package/gstreamer1/gst1-plugins-bad/0012-mssdemux-parse-protection-data.patch
+++ b/package/gstreamer1/gst1-plugins-bad/0012-mssdemux-parse-protection-data.patch
@@ -1,0 +1,325 @@
+From d67528ffbff0e1ae2558557e14eba800df57ecb6 Mon Sep 17 00:00:00 2001
+From: Charlie Turner <chturne@gmail.com>
+Date: Fri, 25 May 2018 09:43:30 +0100
+Subject: [PATCH] [mssdemux] Parse playready payload.
+
+Look at the playready specific data payload to extract default key ids
+for decrypting samples. The format of this payload seems to be
+proprietary.
+---
+ ext/smoothstreaming/gstmssdemux.c    |  19 +++-
+ ext/smoothstreaming/gstmssmanifest.c | 155 +++++++++++++++++++++++++--
+ ext/smoothstreaming/gstmssmanifest.h |   1 +
+ 3 files changed, 164 insertions(+), 11 deletions(-)
+
+diff --git a/ext/smoothstreaming/gstmssdemux.c b/ext/smoothstreaming/gstmssdemux.c
+index 26147fd8b..5802c98ff 100644
+--- a/ext/smoothstreaming/gstmssdemux.c
++++ b/ext/smoothstreaming/gstmssdemux.c
+@@ -465,7 +465,7 @@ gst_mss_demux_setup_streams (GstAdaptiveDemux * demux)
+         gst_adaptive_demux_stream_new (GST_ADAPTIVE_DEMUX_CAST (mssdemux),
+         srcpad);
+     stream->manifest_stream = manifeststream;
+-    stream->adapter = gst_adapter_new();
++    stream->adapter = gst_adapter_new ();
+     gst_mss_stream_set_active (manifeststream, TRUE);
+     active_streams = g_slist_prepend (active_streams, stream);
+   }
+@@ -508,6 +508,18 @@ gst_mss_demux_setup_streams (GstAdaptiveDemux * demux)
+           gst_event_new_protection (protection_system_id, protection_buffer,
+           "smooth-streaming");
+ 
++      GstBuffer *key_id = gst_mss_manifest_get_key_id (mssdemux->manifest);
++      if (!gst_buffer_get_size (key_id)) {
++        GST_WARNING_OBJECT (stream,
++            "protected manifest, but no key ids available");
++      } else {
++        GST_LOG_OBJECT (stream,
++            "Adding key id to the protection event of size %lu",
++            gst_buffer_get_size (key_id));
++        GstStructure *structure = gst_event_writable_structure (event);
++        gst_structure_set (structure, "key_id", GST_TYPE_BUFFER, key_id, NULL);
++      }
++
+       GST_LOG_OBJECT (stream, "Queuing Protection event on source pad");
+       gst_adaptive_demux_stream_queue_event ((GstAdaptiveDemuxStream *) stream,
+           event);
+@@ -700,7 +712,7 @@ gst_mss_demux_update_manifest_data (GstAdaptiveDemux * demux,
+ 
+ static GstFlowReturn
+ gst_mss_demux_data_received (GstAdaptiveDemux * demux,
+-    GstAdaptiveDemuxStream * stream, GstBuffer *buffer)
++    GstAdaptiveDemuxStream * stream, GstBuffer * buffer)
+ {
+   GstMssDemux *mssdemux = GST_MSS_DEMUX_CAST (demux);
+   GstMssDemuxStream *mssstream = (GstMssDemuxStream *) stream;
+@@ -732,7 +744,8 @@ gst_mss_demux_data_received (GstAdaptiveDemux * demux,
+     }
+   }
+ 
+-  return GST_ADAPTIVE_DEMUX_CLASS (parent_class)->data_received (demux, stream, buffer);
++  return GST_ADAPTIVE_DEMUX_CLASS (parent_class)->data_received (demux, stream,
++      buffer);
+ }
+ 
+ static gboolean
+diff --git a/ext/smoothstreaming/gstmssmanifest.c b/ext/smoothstreaming/gstmssmanifest.c
+index ebbf45482..1ab19daa1 100644
+--- a/ext/smoothstreaming/gstmssmanifest.c
++++ b/ext/smoothstreaming/gstmssmanifest.c
+@@ -28,6 +28,8 @@
+ #include <ctype.h>
+ #include <libxml/parser.h>
+ #include <libxml/tree.h>
++#include <libxml/xpath.h>
++#include <libxml/xpathInternals.h>
+ 
+ /* for parsing h264 codec data */
+ #include <gst/codecparsers/gsth264parser.h>
+@@ -109,6 +111,10 @@ struct _GstMssManifest
+   GString *protection_system_id;
+   gchar *protection_data;
+ 
++  // FIXME: There can be multiple key ids present in protected manifests.
++  gchar *key_id;
++  gsize key_id_len;
++
+   GSList *streams;
+ };
+ 
+@@ -283,17 +289,18 @@ _gst_mss_stream_init (GstMssManifest * manifest, GstMssStream * stream,
+         GstClockTime accumulated_time, look_ahead_estimation_time;
+ 
+         if (first_fragment_time == GST_CLOCK_TIME_NONE && builder.fragments)
+-            first_fragment_time = builder.fragment_time_accum;
++          first_fragment_time = builder.fragment_time_accum;
+         accumulated_time =
+             (builder.fragment_time_accum
+-            + ((GstMssStreamFragment*)builder.fragments->data)->duration
++            + ((GstMssStreamFragment *) builder.fragments->data)->duration
+             - first_fragment_time) * GST_SECOND / DEFAULT_TIMESCALE;
+         look_ahead_estimation_time = accumulated_time
+-            * (builder.fragment_number + manifest->look_ahead_fragment_count + 5)
++            * (builder.fragment_number + manifest->look_ahead_fragment_count +
++            5)
+             / builder.fragment_number;
+         if (dvr_window == GST_CLOCK_TIME_NONE
+             || look_ahead_estimation_time >= dvr_window)
+-            break;
++          break;
+       }
+     } else if (node_has_type (iter, MSS_NODE_STREAM_QUALITY)) {
+       GstMssStreamQuality *quality = gst_mss_stream_quality_new (iter);
+@@ -305,10 +312,10 @@ _gst_mss_stream_init (GstMssManifest * manifest, GstMssStream * stream,
+ 
+   if (stream->has_live_fragments) {
+     /* Skip all fragments except the first one (more recently added) */
+-    GList* skipped;
++    GList *skipped;
+ 
+     stream->fragments = builder.fragments;
+-    skipped = g_list_remove_link(builder.fragments, builder.fragments);
++    skipped = g_list_remove_link (builder.fragments, builder.fragments);
+     g_list_free_full (skipped, g_free);
+ 
+     g_queue_init (&stream->live_fragments);
+@@ -333,6 +340,122 @@ _gst_mss_stream_init (GstMssManifest * manifest, GstMssStream * stream,
+   gst_mss_fragment_parser_init (&stream->fragment_parser);
+ }
+ 
++static void
++_gst_mss_parse_protection_data (GstMssManifest * manifest)
++{
++  guchar *decoded_protection_data = NULL;
++  gsize decoded_protection_data_len = 0;
++  xmlChar *protection_data_text = NULL;
++  int protection_data_text_len = 0;
++  xmlDocPtr protection_data_xml = NULL;
++  // Note, this does not need to free'd, freeing the doc ptr will free this.
++  xmlNode *protection_data_root_element = NULL;
++  const xmlChar *protection_data_namespace = NULL;
++  xmlXPathContextPtr xpath_ctx = NULL;
++  xmlXPathObjectPtr xpath_obj = NULL;
++  xmlNodeSetPtr key_id_node = NULL;
++  gsize protection_data_xml_len = 0;
++  guchar *start_tag = NULL;
++
++  decoded_protection_data =
++      g_base64_decode (manifest->protection_data, &decoded_protection_data_len);
++
++  start_tag = decoded_protection_data;
++
++  // The protection data starts with a 10-byte PlayReady version
++  // header that needs to be skipped over to avoid XML parsing
++  // errors.
++  while (start_tag && *start_tag != '<')
++    start_tag++;
++
++  if (!start_tag) {
++    GST_ERROR ("failed to find a start tag in protection data payload");
++    goto beach;
++  }
++
++  protection_data_xml_len =
++      decoded_protection_data_len - (start_tag - decoded_protection_data);
++  protection_data_xml =
++      xmlReadMemory ((const gchar *) start_tag, protection_data_xml_len,
++      "protection_data", "utf-16", 0);
++
++  if (!protection_data_xml) {
++    GST_ERROR ("failed to parse protection data XML");
++    goto beach;
++  }
++
++  if (gst_debug_category_get_threshold (GST_CAT_DEFAULT) >= GST_LEVEL_MEMDUMP) {
++    xmlDocDumpMemoryEnc (protection_data_xml, &protection_data_text,
++        &protection_data_text_len, "utf8");
++    GST_MEMDUMP ("protection data XML", protection_data_text,
++        protection_data_text_len);
++    xmlFree (protection_data_text);
++  }
++
++  protection_data_root_element = xmlDocGetRootElement (protection_data_xml);
++  if (protection_data_root_element->type != XML_ELEMENT_NODE ||
++      xmlStrcmp (protection_data_root_element->name,
++          (const xmlChar *) "WRMHEADER") || !protection_data_root_element->ns) {
++    GST_ERROR ("invalid protection data XML");
++    goto beach;
++  }
++
++  xpath_ctx = xmlXPathNewContext (protection_data_xml);
++  if (!xpath_ctx) {
++    GST_ERROR ("failed to create xpath context");
++    goto beach;
++  }
++
++  protection_data_namespace = protection_data_root_element->ns->href;
++  if (xmlXPathRegisterNs (xpath_ctx, (const xmlChar *) "prhdr",
++          protection_data_namespace) < 0) {
++    GST_ERROR ("failed to register XML namespace");
++    goto beach;
++  }
++
++  xpath_obj =
++      xmlXPathEvalExpression ((const xmlChar *) "//prhdr:KID", xpath_ctx);
++  if (!xpath_obj) {
++    GST_DEBUG ("failed to eval XPath expression");
++    goto beach;
++  }
++
++  key_id_node = xpath_obj->nodesetval;
++  int num_key_ids = key_id_node ? key_id_node->nodeNr : 0;
++
++  GST_DEBUG ("found %d key ids", num_key_ids);
++
++  if (num_key_ids != 0 && (key_id_node->nodeTab[0]->type == XML_ELEMENT_NODE)) {
++    xmlChar *encoded_key_id = xmlNodeGetContent (key_id_node->nodeTab[0]);
++    gsize decoded_key_id_len;
++    guchar *decoded_key_id =
++        g_base64_decode ((const gchar *) encoded_key_id, &decoded_key_id_len);
++
++    GST_MEMDUMP ("key retrieved", decoded_key_id, decoded_key_id_len);
++
++    manifest->key_id = g_realloc (manifest->key_id, decoded_key_id_len);
++    memcpy (manifest->key_id, decoded_key_id, decoded_key_id_len);
++    manifest->key_id_len = decoded_key_id_len;
++
++    xmlFree (encoded_key_id);
++    g_free (decoded_key_id);
++  } else {
++    GST_ERROR ("invalid XML payload");
++    goto beach;
++  }
++
++beach:
++  if (decoded_protection_data)
++    g_free (decoded_protection_data);
++  if (xpath_ctx)
++    xmlXPathFreeContext (xpath_ctx);
++  if (xpath_obj)
++    xmlXPathFreeObject (xpath_obj);
++  if (protection_data_xml)
++    xmlFreeDoc (protection_data_xml);
++
++  return;
++}
+ 
+ static void
+ _gst_mss_parse_protection (GstMssManifest * manifest,
+@@ -362,6 +485,7 @@ _gst_mss_parse_protection (GstMssManifest * manifest,
+ 
+       manifest->protection_system_id = system_id;
+       manifest->protection_data = (gchar *) xmlNodeGetContent (nodeiter);
++      _gst_mss_parse_protection_data (manifest);
+       xmlFree (system_id_attribute);
+       break;
+     }
+@@ -418,6 +542,9 @@ gst_mss_manifest_new (GstBuffer * data)
+     }
+   }
+ 
++  manifest->key_id = NULL;
++  manifest->key_id_len = 0;
++
+   for (nodeiter = root->children; nodeiter; nodeiter = nodeiter->next) {
+     if (nodeiter->type == XML_ELEMENT_NODE
+         && (strcmp ((const char *) nodeiter->name, "StreamIndex") == 0)) {
+@@ -464,6 +591,9 @@ gst_mss_manifest_free (GstMssManifest * manifest)
+ 
+   g_slist_free_full (manifest->streams, (GDestroyNotify) gst_mss_stream_free);
+ 
++  if (manifest->key_id)
++    g_free (manifest->key_id);
++
+   if (manifest->protection_system_id != NULL)
+     g_string_free (manifest->protection_system_id, TRUE);
+   xmlFree (manifest->protection_data);
+@@ -486,6 +616,15 @@ gst_mss_manifest_get_protection_data (GstMssManifest * manifest)
+   return manifest->protection_data;
+ }
+ 
++GstBuffer *
++gst_mss_manifest_get_key_id (GstMssManifest * manifest)
++{
++  GstBuffer *key_id_buffer =
++      gst_buffer_new_allocate (NULL, manifest->key_id_len, NULL);
++  gst_buffer_fill (key_id_buffer, 0, manifest->key_id, manifest->key_id_len);
++  return key_id_buffer;
++}
++
+ GSList *
+ gst_mss_manifest_get_streams (GstMssManifest * manifest)
+ {
+@@ -1267,7 +1406,7 @@ gst_mss_stream_seek (GstMssStream * stream, gboolean forward,
+   GST_DEBUG ("Stream %s seeking to %" G_GUINT64_FORMAT, stream->url, time);
+   for (iter = stream->fragments; iter; iter = g_list_next (iter)) {
+     fragment = iter->data;
+-    if(stream->has_live_fragments){
++    if (stream->has_live_fragments) {
+       if (fragment->time + fragment->repetitions * fragment->duration > time)
+         stream->current_fragment = iter;
+       break;
+@@ -1583,7 +1722,7 @@ gst_mss_stream_fragment_parse (GstMssStream * stream, GstBuffer * buffer)
+     GstMssStreamFragment *fragment;
+ 
+     if (last == NULL)
+-        break;
++      break;
+     fragment = g_new (GstMssStreamFragment, 1);
+     fragment->number = last->number + 1;
+     fragment->repetitions = 1;
+diff --git a/ext/smoothstreaming/gstmssmanifest.h b/ext/smoothstreaming/gstmssmanifest.h
+index 29545af88..3f9f49ada 100644
+--- a/ext/smoothstreaming/gstmssmanifest.h
++++ b/ext/smoothstreaming/gstmssmanifest.h
+@@ -55,6 +55,7 @@ GstClockTime gst_mss_manifest_get_min_fragment_duration (GstMssManifest * manife
+ const gchar * gst_mss_manifest_get_protection_system_id (GstMssManifest * manifest);
+ const gchar * gst_mss_manifest_get_protection_data (GstMssManifest * manifest);
+ gboolean gst_mss_manifest_get_live_seek_range (GstMssManifest * manifest, gint64 * start, gint64 * stop);
++GstBuffer * gst_mss_manifest_get_key_id (GstMssManifest * manifest);
+ 
+ GstMssStreamType gst_mss_stream_get_type (GstMssStream *stream);
+ GstCaps * gst_mss_stream_get_caps (GstMssStream * stream);
+-- 
+2.17.1
+

--- a/package/gstreamer1/gst1-plugins-good/0014-qtdemux-default-key-ids.patch
+++ b/package/gstreamer1/gst1-plugins-good/0014-qtdemux-default-key-ids.patch
@@ -1,0 +1,134 @@
+From 15f68f30b47fa510b73dc6fa96f4dadd929b384e Mon Sep 17 00:00:00 2001
+From: Charlie Turner <chturne@gmail.com>
+Date: Fri, 25 May 2018 14:08:17 +0100
+Subject: [PATCH] [qtdemux] Check if an upstream demuxer provided a default
+ kid.
+
+Smooth streaming demuxers do not send boxes containing metadata about
+the stream. They have to send metadata "out-of-band".
+
+For piff encoded streams, if no box has been found containing a default
+kid for the sample, check if an upstream demuxer has provided one via a
+protection event, and use this as a fallback.
+---
+ gst/isomp4/qtdemux.c | 55 ++++++++++++++++++++++++++++++++++++++++----
+ 1 file changed, 51 insertions(+), 4 deletions(-)
+
+diff --git a/gst/isomp4/qtdemux.c b/gst/isomp4/qtdemux.c
+index bad9ca759..d033f98fd 100644
+--- a/gst/isomp4/qtdemux.c
++++ b/gst/isomp4/qtdemux.c
+@@ -407,6 +407,9 @@ struct _QtDemuxStream
+   guint32 protection_scheme_type;
+   guint32 protection_scheme_version;
+   gpointer protection_scheme_info;      /* specific to the protection scheme */
++
++  GstBuffer *default_kid;
++
+   GQueue protection_scheme_event_queue;
+ };
+ 
+@@ -1854,6 +1857,7 @@ _create_stream (void)
+   stream->alignment = 1;
+   stream->duration_last_moof = 0;
+   g_queue_init (&stream->protection_scheme_event_queue);
++  stream->default_kid = NULL;
+   return stream;
+ }
+ 
+@@ -2284,6 +2288,32 @@ gst_qtdemux_handle_sink_event (GstPad * sinkpad, GstObject * parent,
+     case GST_EVENT_PROTECTION:
+     {
+       const gchar *system_id = NULL;
++      GstBuffer *default_key_id = NULL;
++      const GstStructure *structure;
++      QtDemuxStream *stream = NULL;
++      GstMapInfo map;
++
++      structure = gst_event_get_structure (event);
++      if (gst_structure_has_field_typed (structure, "key_id", GST_TYPE_BUFFER)) {
++        gst_structure_get (structure, "key_id", GST_TYPE_BUFFER,
++            &default_key_id, NULL);
++        GST_DEBUG_OBJECT (demux,
++            "received a default key id of size %" G_GSIZE_FORMAT,
++            gst_buffer_get_size (default_key_id));
++
++        if (gst_debug_category_get_threshold (GST_CAT_DEFAULT) >=
++            GST_LEVEL_MEMDUMP) {
++          gst_buffer_map (default_key_id, &map, GST_MAP_READ);
++          GST_MEMDUMP_OBJECT (demux, "default key id", (guint8 *) map.data,
++              map.size);
++          gst_buffer_unmap (default_key_id, &map);
++        }
++
++        if (demux->n_streams) {
++          stream = demux->streams[0];
++          stream->default_kid = default_key_id;
++        }
++      }
+ 
+       gst_event_parse_protection (event, &system_id, NULL, NULL);
+       GST_DEBUG_OBJECT (demux, "Received protection event for system ID %s",
+@@ -2436,6 +2466,8 @@ gst_qtdemux_stream_clear (GstQTDemux * qtdemux, QtDemuxStream * stream)
+   g_queue_foreach (&stream->protection_scheme_event_queue,
+       (GFunc) gst_event_unref, NULL);
+   g_queue_clear (&stream->protection_scheme_event_queue);
++  if (stream->default_kid)
++    gst_buffer_unref (stream->default_kid);
+   gst_qtdemux_stream_flush_segments_data (qtdemux, stream);
+   gst_qtdemux_stream_flush_samples_data (qtdemux, stream);
+ }
+@@ -2663,6 +2695,18 @@ qtdemux_parse_piff (GstQTDemux * qtdemux, const guint8 * buffer, gint length,
+   } else if ((flags & 0x000002)) {
+     uses_sub_sample_encryption = TRUE;
+   }
++  // In the case of smooth streaming, we never get moov boxes and their
++  // default encryption metadata. Instead, the demuxer has to parse this
++  // information out of the playready specific payloads and make it availble
++  // somehow to us.
++  if (!gst_structure_has_field (ss_info->default_properties, "kid")) {
++    if (!stream->default_kid) {
++      GST_WARNING_OBJECT (qtdemux, "No available key id for sample");
++    } else {
++      gst_structure_set (ss_info->default_properties, "kid", GST_TYPE_BUFFER,
++          stream->default_kid, NULL);
++    }
++  }
+ 
+   if (!gst_byte_reader_get_uint32_be (&br, &qtdemux->cenc_aux_sample_count)) {
+     GST_ERROR_OBJECT (qtdemux, "Error getting box's sample count field");
+@@ -5418,16 +5462,19 @@ gst_qtdemux_decorate_and_push_buffer (GstQTDemux * qtdemux,
+     }
+ 
+     if (info->crypto_info == NULL)
+-      GST_DEBUG_OBJECT (qtdemux, "cenc metadata hasn't been parsed yet, pushing buffer as if it wasn't encrypted");
++      GST_DEBUG_OBJECT (qtdemux,
++          "cenc metadata hasn't been parsed yet, pushing buffer as if it wasn't encrypted");
+     else {
+-      index = stream->sample_index - (stream->n_samples - info->crypto_info->len);
++      index =
++          stream->sample_index - (stream->n_samples - info->crypto_info->len);
+       if (G_LIKELY (index >= 0 && index < info->crypto_info->len)) {
+         /* steal structure from array */
+         crypto_info = g_ptr_array_index (info->crypto_info, index);
+         g_ptr_array_index (info->crypto_info, index) = NULL;
+         GST_LOG_OBJECT (qtdemux, "attaching cenc metadata [%u]", index);
+         if (!crypto_info || !gst_buffer_add_protection_meta (buf, crypto_info))
+-          GST_ERROR_OBJECT (qtdemux, "failed to attach cenc metadata to buffer");
++          GST_ERROR_OBJECT (qtdemux,
++              "failed to attach cenc metadata to buffer");
+       }
+     }
+   }
+@@ -8968,7 +9015,7 @@ done:
+ 
+   /* push based does not handle segments, so act accordingly here,
+    * and warn if applicable */
+-  if (!qtdemux->pullbased /* && !allow_pushbased_edts */) {
++  if (!qtdemux->pullbased /* && !allow_pushbased_edts */ ) {
+     GST_WARNING_OBJECT (qtdemux, "streaming; discarding edit list segments");
+     /* remove and use default one below, we stream like it anyway */
+     g_free (stream->segments);
+-- 
+2.17.1
+


### PR DESCRIPTION
There are some style changes intermixed here. I work from the gstreamer git branches, and to commit to them they force the use of gst-indent, so I went with it.