### PR TITLE
[icu58-2] Add patch to disable LDFLAGS - "nodefaultlibs -nostdlib"

### DIFF
--- a/package/icu/58.2/0004-link-icudata-as-data-only.patch
+++ b/package/icu/58.2/0004-link-icudata-as-data-only.patch
@@ -1,0 +1,1 @@
+../0004-link-icudata-as-data-only.patch


### PR DESCRIPTION
This is required to link standard libs with libicudata.so.58