### PR TITLE
[libsoup] Disconnect the signal before clearing the connection object

### DIFF
--- a/package/libsoup/0004-soup-socket-disconnect-signal-before-clearing-connection-object.patch
+++ b/package/libsoup/0004-soup-socket-disconnect-signal-before-clearing-connection-object.patch
@@ -1,0 +1,11 @@
+diff --git a/libsoup/soup-socket.c b/libsoup/soup-socket.c
+index 16f29c8..a4e0fd9 100644
+--- a/libsoup/soup-socket.c
++++ b/libsoup/soup-socket.c
+@@ -188,6 +188,7 @@ disconnect_internal (SoupSocket *sock, gboolean close)
+	g_clear_object (&priv->gsock);
+	if (priv->conn && close) {
+		g_io_stream_close (priv->conn, NULL, NULL);
++		g_signal_handlers_disconnect_by_data (priv->conn, sock);
+		g_clear_object (&priv->conn);
+	}


### PR DESCRIPTION
Disconnect the signal on disconnect_internal before clearing the connection object. 
There is the same issue on Bugzilla Webkit and a patch for it:
https://trac.webkit.org/changeset/237542/webkit
Without this patch sometimes WPENetworkProcess crashes on WPE 2.22 during SSL tests.

This issue is solved on a newer version of libsoup than 2.54. (there is already included this patch)
To fix that crash we can use this patch or update libsoup to the newer version. 
If you update libsoup, please let us know.