### PR TITLE
[gst1-bcm] apply patches for VSS also when building from custom source

### DIFF
--- a/package/gstreamer1/gst1-bcm/gst1-bcm.mk
+++ b/package/gstreamer1/gst1-bcm/gst1-bcm.mk
@@ -177,7 +177,7 @@ define GST1_BCM_APPLY_VSS_FIX
  package/vss-sdk/gst1/brcm.no_opus.fix.sh ${@D}
  package/vss-sdk/gst1/brcm.fix.sh ${@D}
 endef
-GST1_BCM_POST_PATCH_HOOKS += GST1_BCM_APPLY_VSS_FIX
+GST1_BCM_PRE_CONFIGURE_HOOKS += GST1_BCM_APPLY_VSS_FIX
 endif
 
 $(eval $(autotools-package))


### PR DESCRIPTION
Currently the patches for VSS platform were applied only when source
code wasn't from custom location. Those patches are necessary in both
release and development cases and are necessary just before the
configure step.

This is now changed to apply patches as pre-configure step not as
post patch step.