### PR TITLE
[Cobalt][WPE-556] Bump cobalt to the latest greatest

### DIFF
--- a/package/cobalt/cobalt.mk
+++ b/package/cobalt/cobalt.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-COBALT_VERSION = c0e5376052e4c99e9e99866198e78fcff61d42f3
+COBALT_VERSION = 2b05944b27596a50c2d94b02b358fb289980a990
 COBALT_SITE_METHOD = git
 COBALT_SITE = git@github.com:Metrological/cobalt
 COBALT_INSTALL_STAGING = YES


### PR DESCRIPTION
Bump is needed because we added the functionality of changing the Cobalt URL during runtime. The new version of the Cobalt plugin will not compile with the older hash of cobalt because of a missing header.