### PR TITLE
Wayland egl bnxs support on bcm-refsw:19.1

### DIFF
--- a/package/bcm-refsw/0007-static_assert.patch
+++ b/package/bcm-refsw/0007-static_assert.patch
@@ -1,6 +1,6 @@
---- BSEAV/lib/gpu/vc5/platform/nexus/display_nexus.c.orig	2019-01-23 17:21:13.301691128 -0500
-+++ BSEAV/lib/gpu/vc5/platform/nexus/display_nexus.c	2019-01-23 17:22:37.941918452 -0500
-@@ -271,7 +271,6 @@
+--- ./BSEAV/lib/gpu/vc5/platform/nexus/display_nexus.c.orig	2020-02-22 08:04:56.645613174 +0530
++++ ./BSEAV/lib/gpu/vc5/platform/nexus/display_nexus.c	2020-02-22 08:05:03.241560692 +0530
+@@ -268,7 +268,6 @@
  
  static void SetWindowInfo(WindowInfo *dst, NXPL_NativeWindowInfoEXT *src)
  {

--- a/package/bcm-refsw/0007-static_assert.patch
+++ b/package/bcm-refsw/0007-static_assert.patch
@@ -1,0 +1,10 @@
+--- BSEAV/lib/gpu/vc5/platform/nexus/display_nexus.c.orig	2019-01-23 17:21:13.301691128 -0500
++++ BSEAV/lib/gpu/vc5/platform/nexus/display_nexus.c	2019-01-23 17:22:37.941918452 -0500
+@@ -271,7 +271,6 @@
+ 
+ static void SetWindowInfo(WindowInfo *dst, NXPL_NativeWindowInfoEXT *src)
+ {
+-   static_assert(sizeof(WindowInfo) == sizeof(NXPL_NativeWindowInfoEXT), "sizeof(WindowInfo) & sizeof(NXPL_NativeWindowInfoEXT) need to match");
+    dst->width = src->width;
+    dst->height = src->height;
+    dst->x = src->x;

--- a/package/bcm-refsw/wayland-egl.inc
+++ b/package/bcm-refsw/wayland-egl.inc
@@ -1,5 +1,6 @@
 WAYLAND_EGL_DIR=${BCM_REFSW_VCX}/platform/wayland/
 define BCM_REFSW_BUILD_WAYLAND_EGL
+if [ $(shell expr $(BCM_REFSW_VERSION) \< 19.1) = 1 ]; then \
     $(TARGET_CONFIGURE_OPTS) \
     $(TARGET_MAKE_ENV) \
     $(BCM_REFSW_CONF_OPTS) \
@@ -8,8 +9,8 @@ define BCM_REFSW_BUILD_WAYLAND_EGL
              WAYLAND_TOP=${STAGING_DIR}/usr \
             WAYLAND_SCANNER=${HOST_DIR}/usr/bin/wayland-scanner \
             APPLIBS_TARGET_LIB_DIR=${BCM_REFSW_BIN} \
-            APPLIBS_TARGET_INC_DIR=${BCM_REFSW_BIN}/include
-
+            APPLIBS_TARGET_INC_DIR=${BCM_REFSW_BIN}/include; \
+    \
     $(TARGET_CONFIGURE_OPTS) \
     $(TARGET_MAKE_ENV) \
     $(BCM_REFSW_CONF_OPTS) \
@@ -18,8 +19,8 @@ define BCM_REFSW_BUILD_WAYLAND_EGL
             WAYLAND_SCANNER=${HOST_DIR}/usr/bin/wayland-scanner \
              WAYLAND_TOP=${STAGING_DIR}/usr \
             APPLIBS_TARGET_LIB_DIR=${BCM_REFSW_BIN} \
-            APPLIBS_TARGET_INC_DIR=${BCM_REFSW_BIN}/include
-
+            APPLIBS_TARGET_INC_DIR=${BCM_REFSW_BIN}/include; \
+fi
 if [ $(shell expr $(BCM_REFSW_VERSION) \>= 17.1)$(shell expr $(BCM_REFSW_VERSION) \<= 17.3) = 11 ]; then \
     $(TARGET_CONFIGURE_OPTS) \
     $(TARGET_MAKE_ENV) \
@@ -42,7 +43,7 @@ if [ $(shell expr $(BCM_REFSW_VERSION) \>= 17.1)$(shell expr $(BCM_REFSW_VERSION
             APPLIBS_TARGET_INC_DIR=${BCM_REFSW_BIN}/include ; \
 fi
 
-if [ $(shell expr $(BCM_REFSW_VERSION) \>= 17.4) = 1 ]; then \
+if [ $(shell expr $(BCM_REFSW_VERSION) \>= 17.4)$(shell expr $(BCM_REFSW_VERSION) \< 19.1) = 11 ]; then \
     $(TARGET_CONFIGURE_OPTS) \
     $(TARGET_MAKE_ENV) \
     $(BCM_REFSW_CONF_OPTS) \
@@ -59,17 +60,12 @@ endef
 ifeq ($(BCM_REFSW_PLATFORM_VC),vc5)
     define BCM_REFSW_INSTALL_STAGING_WAYLAND_EGL_GPU
             $(INSTALL) -d -m 0755 $(STAGING_DIR)/usr/include/interface/khronos/include/
-            $(INSTALL) -d -m 0755 $(STAGING_DIR)/usr/include/interface/khronos/include/bcg_abstract/
+            $(INSTALL) -d -m 0755 $(STAGING_DIR)/usr/include/interface/khronos/include/bcg_abstract
 
             ln -sf ../../../EGL $(STAGING_DIR)/usr/include/interface/khronos/include/
             ln -sf ../../../GLES $(STAGING_DIR)/usr/include/interface/khronos/include/
             ln -sf ../../../GLES2 $(STAGING_DIR)/usr/include/interface/khronos/include/
             ln -sf ../helpers $(STAGING_DIR)/usr/include/interface/khronos/include/
-
-            $(INSTALL) -m 0644 $(@D)/BSEAV/lib/gpu/vc5/platform/nexus/*.h $(STAGING_DIR)/usr/include/interface/khronos/include
-            $(INSTALL) -m 0644 $(@D)/BSEAV/lib/gpu/vc5/driver/libs/khrn/egl/platform/bcg_abstract/*.h $(STAGING_DIR)/usr/include/interface/khronos/include/bcg_abstract
-            $(INSTALL) -m 0644 $(@D)/BSEAV/lib/gpu/vc5/driver/libs/platform/bcg_abstract/*.h $(STAGING_DIR)/usr/include/interface/khronos/include/bcg_abstract
-            $(INSTALL) -m 0644 $(@D)/BSEAV/lib/gpu/vc5/driver/libs/platform/*.h $(STAGING_DIR)/usr/include/interface/khronos/include
 
             $(INSTALL) -d -m 0755 $(STAGING_DIR)/usr/include/vcos
             $(INSTALL) -d -m 0755 $(STAGING_DIR)/usr/include/vcos/include
@@ -90,8 +86,18 @@ ifeq ($(BCM_REFSW_PLATFORM_VC),vc5)
             $(INSTALL) -m 0644 $(@D)/BSEAV/lib/gpu/vc5/driver/libs/util/log/*.h $(STAGING_DIR)/usr/include/libs/util/log
             $(INSTALL) -m 0644 $(@D)/BSEAV/lib/gpu/vc5/driver/libs/core/v3d/*.h $(STAGING_DIR)/usr/include/libs/core/v3d
 
+            $(INSTALL) -m 0644 $(@D)/BSEAV/lib/gpu/vc5/platform/nexus/*.h $(STAGING_DIR)/usr/include/interface/khronos/include
+            $(INSTALL) -m 0644 $(@D)/BSEAV/lib/gpu/vc5/driver/libs/khrn/egl/platform/bcg_abstract/*.h $(STAGING_DIR)/usr/include/interface/khronos/include/bcg_abstract
+            $(INSTALL) -m 0644 $(@D)/BSEAV/lib/gpu/vc5/driver/libs/platform/*.h $(STAGING_DIR)/usr/include/interface/khronos/include
+
+            if [ $(shell expr $(BCM_REFSW_VERSION) \>= 19.1) = 1 ]; then \
+                $(INSTALL) -m 0644 $(@D)/BSEAV/lib/gpu/vc5/driver/libs/platform/stb/*.h $(STAGING_DIR)/usr/include/interface/khronos/include/bcg_abstract; \
+                $(INSTALL) -m 0644 $(@D)/BSEAV/lib/gpu/vc5/driver/libs/platform/stb/gmem_plat.inl $(STAGING_DIR)/usr/include/interface/khronos/include; \
+            else \
+                $(INSTALL) -m 0644 $(@D)/BSEAV/lib/gpu/vc5/driver/libs/platform/bcg_abstract/*.h $(STAGING_DIR)/usr/include/interface/khronos/include/bcg_abstract; \
+                $(INSTALL) -m 0644 $(@D)/BSEAV/lib/gpu/vc5/driver/libs/platform/bcg_abstract/gmem_plat.inl $(STAGING_DIR)/usr/include/interface/khronos/include; \
+            fi
             $(INSTALL) -m 0644 $(@D)/BSEAV/lib/gpu/vc5/driver/libs/platform/gmem.inl $(STAGING_DIR)/usr/include/interface/khronos/include
-            $(INSTALL) -m 0644 $(@D)/BSEAV/lib/gpu/vc5/driver/libs/platform/bcg_abstract/gmem_plat.inl $(STAGING_DIR)/usr/include/interface/khronos/include
 
             #ursr16.2 extra copy
             $(INSTALL) -m 0755 -d $(STAGING_DIR)/usr/include/GLES3
@@ -112,11 +118,6 @@ ifeq ($(BCM_REFSW_PLATFORM_VC),vc5)
             $(INSTALL) -m 0644 $(@D)/BSEAV/lib/gpu/vc5/platform/common/*.h            $(STAGING_DIR)/usr/share/wayland-egl/common
             $(INSTALL) -m 0755 $(@D)/BSEAV/lib/gpu/vc5/platform/common/*.cpp          $(STAGING_DIR)/usr/share/wayland-egl/common
 
-            #if [ -e $(@D)/trellis/display/weston/include/EGL/eglext.h ]; then \
-            #    $(INSTALL) -m 0755 $(@D)/trellis/display/weston/include/EGL/eglext.h        $(STAGING_DIR)/usr/include/EGL; \
-            #    $(INSTALL) -m 0755 $(@D)/trellis/display/weston/include/EGL/eglext_brcm.h   $(STAGING_DIR)/usr/include/EGL; \
-            #fi
-
             if [ -e $(@D)/magnum/basemodules/chp/include/${BCM_REFSW_BCHP_CHIP}/rdb/${BCM_REFSW_BCHP_VER_LOWER}/bchp_common.h ]; then \
                 $(INSTALL) -m 0755 $(@D)/magnum/basemodules/chp/include/${BCM_REFSW_BCHP_CHIP}/rdb/${BCM_REFSW_BCHP_VER_LOWER}/bchp_common.h        $(STAGING_DIR)/usr/include;\
             fi
@@ -126,6 +127,12 @@ ifeq ($(BCM_REFSW_PLATFORM_VC),vc5)
             fi
             if [ -e $(@D)/magnum/basemodules/chp/include/${BCM_REFSW_BCHP_CHIP}/rdb/${BCM_REFSW_BCHP_VER_LOWER}/bchp_m2mc.h ]; then \
                 $(INSTALL) -m 0755 $(@D)/magnum/basemodules/chp/include/${BCM_REFSW_BCHP_CHIP}/rdb/${BCM_REFSW_BCHP_VER_LOWER}/bchp_m2mc.h         $(STAGING_DIR)/usr/include; \
+            fi
+            if [ $(shell expr $(BCM_REFSW_VERSION) \>= 19.1) = 1 ]; then \
+                $(INSTALL) -d -m 0755 $(STAGING_DIR)/usr/include/libs/core/gfx_buffer; \
+                $(INSTALL) -m 0755 $(@D)/BSEAV/lib/gpu/vc5/driver/libs/core/gfx_buffer/*.h $(STAGING_DIR)/usr/include/libs/core/gfx_buffer; \
+                $(INSTALL) -d -m 0755 $(STAGING_DIR)/usr/include/libs/core/lfmt; \
+                $(INSTALL) -m 0755 $(@D)/BSEAV/lib/gpu/vc5/driver/libs/core/lfmt/*.h $(STAGING_DIR)/usr/include/libs/core/lfmt; \
             fi
 endef
 else
@@ -142,7 +149,9 @@ define BCM_REFSW_INSTALL_WAYLAND_EGL_DEV
 	$(call BCM_REFSW_INSTALL_WAYLAND_EGL,  $(STAGING_DIR))
 
     $(INSTALL) -m 644 package/bcm-refsw/${BCM_REFSW_PLATFORM_VC}/wayland-egl.pc $(STAGING_DIR)/usr/lib/pkgconfig/
-    $(INSTALL) -m 644 $(WAYLAND_EGL_DIR)/autogen/*.h $(STAGING_DIR)/usr/include/refsw/
+    if [ $(shell expr $(BCM_REFSW_VERSION) \< 19.1) = 1 ]; then \
+        $(INSTALL) -m 644 $(WAYLAND_EGL_DIR)/autogen/*.h $(STAGING_DIR)/usr/include/refsw/; \
+    fi
 
     $(INSTALL) -d -m 0755 $(STAGING_DIR)/usr/share
     $(INSTALL) -d -m 0755 $(STAGING_DIR)/usr/share/wayland-egl
@@ -172,13 +181,21 @@ define BCM_REFSW_INSTALL_WAYLAND_EGL_DEV
 endef
 
 define BCM_REFSW_INSTALL_WAYLAND_EGL
-    $(INSTALL) -m 644 -D $(WAYLAND_EGL_DIR)/lib_${BCM_REFSW_PLATFORM}_release/*.so $(1)/usr/lib
+    if [ $(shell expr $(BCM_REFSW_VERSION) \< 19.1) = 1 ]; then \
+        $(INSTALL) -m 644 -D $(WAYLAND_EGL_DIR)/lib_${BCM_REFSW_PLATFORM}_release/*.so $(1)/usr/lib; \
+    fi
     if [ $(shell expr $(BCM_REFSW_VERSION) \>= 17.1)$(shell expr $(BCM_REFSW_VERSION) \<= 17.3) = 11 ]; then \
        $(INSTALL) -m 644 -D $(WAYLAND_EGL_DIR)/lib_${BCM_REFSW_PLATFORM}_release/libbcm_wayland_egl.so $(1)/usr/lib/libwayland-egl.so ;\
     fi
     if [ $(shell expr $(BCM_REFSW_VERSION) \>= 18.2) = 1 ]; then \
 	$(INSTALL) -d -m 0755 $(STAGING_DIR)/usr/include/libs/util/gfx_util/; \
         $(INSTALL) -m 0755 $(@D)/BSEAV/lib/gpu/${BCM_REFSW_PLATFORM_VC}/driver/libs/util/gfx_util/*.h $(STAGING_DIR)/usr/include/libs/util/gfx_util/; \
-        $(INSTALL) -m 0755 $(@D)/magnum/portinginterface/${BCM_REFSW_PLATFORM_VC}/include/brcmv3d_drm.h $(STAGING_DIR)/usr/include/; \
+    fi
+    if [ $(shell expr $(BCM_REFSW_VERSION) \>= 19.1) = 1 ]; then \
+        $(INSTALL) -m 0755 $(@D)/BSEAV/linux/driver/brcmv3d/include/uapi/drm/brcmv3d_drm.h $(STAGING_DIR)/usr/include/; \
+    else \
+        if [ $(shell expr $(BCM_REFSW_VERSION) \>= 18.2) = 1 ]; then \
+            $(INSTALL) -m 0755 $(@D)/magnum/portinginterface/${BCM_REFSW_PLATFORM_VC}/include/brcmv3d_drm.h $(STAGING_DIR)/usr/include/; \
+        fi \
     fi
 endef

--- a/package/wayland-egl-bnxs/0005-wayland-egl-bnxs.18.3.patch
+++ b/package/wayland-egl-bnxs/0005-wayland-egl-bnxs.18.3.patch
@@ -1,0 +1,217 @@
+diff -auNrd git.orig/configure.ac git/configure.ac
+--- git.orig/configure.ac	2018-11-08 17:13:01.393659647 -0500
++++ git/configure.ac	2018-11-08 17:12:26.161582302 -0500
+@@ -123,6 +123,42 @@
+               [echo "refsw17_3 is disabled"])
+ AM_CONDITIONAL([REFSW_17_3], [test x$REFSW_17_3 = xtrue])
+ 
++AC_ARG_ENABLE([refsw18_1],
++              AS_HELP_STRING([--enable-refsw18_1],[enable refsw18_1 (default is no)]),
++              [
++                case "${enableval}" in
++                 yes) REFSW_18_1=true ;;
++                  no) AC_MSG_ERROR([refsw18_1 is disabled]) ;;
++                   *) AC_MSG_ERROR([bad value ${enableval} for --enable-refsw18_1]) ;;
++                esac
++              ],
++              [echo "refsw18_1 is disabled"])
++AM_CONDITIONAL([REFSW_18_1], [test x$REFSW_18_1 = xtrue])
++
++AC_ARG_ENABLE([refsw18_2],
++              AS_HELP_STRING([--enable-refsw18_2],[enable refsw18_2 (default is no)]),
++              [
++                case "${enableval}" in
++                 yes) REFSW_18_2=true ;;
++                  no) AC_MSG_ERROR([refsw18_2 is disabled]) ;;
++                   *) AC_MSG_ERROR([bad value ${enableval} for --enable-refsw18_2]) ;;
++                esac
++              ],
++              [echo "refsw18_2 is disabled"])
++AM_CONDITIONAL([REFSW_18_2], [test x$REFSW_18_2 = xtrue])
++
++AC_ARG_ENABLE([refsw18_3],
++              AS_HELP_STRING([--enable-refsw18_3],[enable refsw18_3 (default is no)]),
++              [
++                case "${enableval}" in
++                 yes) REFSW_18_3=true ;;
++                  no) AC_MSG_ERROR([refsw18_3 is disabled]) ;;
++                   *) AC_MSG_ERROR([bad value ${enableval} for --enable-refsw18_3]) ;;
++                esac
++              ],
++              [echo "refsw18_3 is disabled"])
++AM_CONDITIONAL([REFSW_18_3], [test x$REFSW_18_3 = xtrue])
++
+ AC_ARG_ENABLE([xg1v3_v3d],
+               AS_HELP_STRING([--enable-xg1v3_v3d],[enable xg1v3_v3d (default is no)]),
+               [
+diff -auNrd git.orig/Makefile.am git/Makefile.am
+--- git.orig/Makefile.am	2018-11-08 17:13:01.393659647 -0500
++++ git/Makefile.am	2018-11-08 17:09:29.793196829 -0500
+@@ -149,6 +149,147 @@
+    ROCKFORD_TOP="${REFSW_BASE}-rdk-linux-gnueabi/broadcom-refsw/unified-17.3-r4.2/rockford"
+ endif
+ 
++if REFSW_18_1
++   $(warning generic RDK is using 18.1 Broadcom SDK version)
++   REFSW_VERSION=${PKG_CONFIG_SYSROOT_DIR}/usr/share/wayland-egl
++
++if ENABLE_VC5
++AM_CFLAGS += -DVCX=5
++libwayland_egl_la_SOURCES += \
++                            $(REFSW_VERSION)/nexus/display_nexus.c \
++                            $(REFSW_VERSION)/nexus/default_nexus.c \
++                            $(REFSW_VERSION)/nexus/display_surface.c \
++                            $(REFSW_VERSION)/nexus/display_nexus_multi.c \
++                            $(REFSW_VERSION)/common/display_helpers.c \
++                            $(REFSW_VERSION)/common/memory_convert.c \
++                            $(REFSW_VERSION)/common/memory_drm.c \
++                            $(REFSW_VERSION)/common/memory_nexus.c \
++                            $(REFSW_VERSION)/common/sched_nexus.c \
++                            $(REFSW_VERSION)/common/display_framework.c \
++                            $(REFSW_VERSION)/common/display_interface.c \
++                            $(REFSW_VERSION)/common/event.c \
++                            $(REFSW_VERSION)/common/fence_interface.c \
++                            $(REFSW_VERSION)/common/fence_queue.c \
++                            $(REFSW_VERSION)/common/perf_event.cpp \
++                            $(REFSW_VERSION)/common/queue.c \
++                            $(REFSW_VERSION)/common/ring_buffer.c \
++                            $(REFSW_VERSION)/common/surface_interface.c \
++                            $(REFSW_VERSION)/common/surface_interface_nexus.c \
++                            $(REFSW_VERSION)/common/swapchain.c
++else
++AM_CFLAGS += -DVCX=3
++AM_CFLAGS += \
++           -I${REFSW_VERSION}/nexus \
++           -I${REFSW_VERSION}/nexus/multi
++libwayland_egl_la_SOURCES += \
++                            $(REFSW_VERSION)/nexus/bitmap.cpp \
++                            $(REFSW_VERSION)/nexus/default_nexus.c \
++                            $(REFSW_VERSION)/common/packet_yv12.c \
++                            $(REFSW_VERSION)/common/packet_rgba.c \
++                            $(REFSW_VERSION)/common/perf_event.cpp \
++                            $(REFSW_VERSION)/common/nexus_surface_memory.c \
++                            $(REFSW_VERSION)/common/memory_nexus.c \
++                            $(REFSW_VERSION)/common/hardware_nexus.cpp \
++                            $(REFSW_VERSION)/common/autoclif.c \
++                            $(REFSW_VERSION)/nexus/multi/worker.cpp \
++                            $(REFSW_VERSION)/nexus/multi/windowinfo.cpp
++endif
++endif
++
++
++if REFSW_18_2
++   $(warning generic RDK is using 18.2 Broadcom SDK version)
++   REFSW_VERSION=${PKG_CONFIG_SYSROOT_DIR}/usr/share/wayland-egl
++
++if ENABLE_VC5
++AM_CFLAGS += -DVCX=5
++libwayland_egl_la_SOURCES += \
++                            $(REFSW_VERSION)/nexus/display_nexus.c \
++                            $(REFSW_VERSION)/nexus/default_nexus.c \
++                            $(REFSW_VERSION)/nexus/display_surface.c \
++                            $(REFSW_VERSION)/nexus/display_nexus_multi.c \
++                            $(REFSW_VERSION)/common/display_helpers.c \
++                            $(REFSW_VERSION)/common/memory_convert.c \
++                            $(REFSW_VERSION)/common/memory_drm.c \
++                            $(REFSW_VERSION)/common/memory_nexus.c \
++                            $(REFSW_VERSION)/common/sched_nexus.c \
++                            $(REFSW_VERSION)/common/display_framework.c \
++                            $(REFSW_VERSION)/common/display_interface.c \
++                            $(REFSW_VERSION)/common/event.c \
++                            $(REFSW_VERSION)/common/fence_interface.c \
++                            $(REFSW_VERSION)/common/fence_queue.c \
++                            $(REFSW_VERSION)/common/perf_event.cpp \
++                            $(REFSW_VERSION)/common/queue.c \
++                            $(REFSW_VERSION)/common/ring_buffer.c \
++                            $(REFSW_VERSION)/common/surface_interface.c \
++                            $(REFSW_VERSION)/common/surface_interface_nexus.c \
++                            $(REFSW_VERSION)/common/swapchain.c
++else
++AM_CFLAGS += -DVCX=3
++AM_CFLAGS += \
++           -I${REFSW_VERSION}/nexus \
++           -I${REFSW_VERSION}/nexus/multi
++libwayland_egl_la_SOURCES += \
++                            $(REFSW_VERSION)/nexus/bitmap.cpp \
++                            $(REFSW_VERSION)/nexus/default_nexus.c \
++                            $(REFSW_VERSION)/common/packet_yv12.c \
++                            $(REFSW_VERSION)/common/packet_rgba.c \
++                            $(REFSW_VERSION)/common/perf_event.cpp \
++                            $(REFSW_VERSION)/common/nexus_surface_memory.c \
++                            $(REFSW_VERSION)/common/memory_nexus.c \
++                            $(REFSW_VERSION)/common/hardware_nexus.cpp \
++                            $(REFSW_VERSION)/common/autoclif.c \
++                            $(REFSW_VERSION)/nexus/multi/worker.cpp \
++                            $(REFSW_VERSION)/nexus/multi/windowinfo.cpp
++endif
++endif
++
++if REFSW_18_3
++   $(warning generic RDK is using 18.3 Broadcom SDK version)
++   REFSW_VERSION=${PKG_CONFIG_SYSROOT_DIR}/usr/share/wayland-egl
++
++if ENABLE_VC5
++AM_CFLAGS += -DVCX=5
++libwayland_egl_la_SOURCES += \
++                            $(REFSW_VERSION)/nexus/display_nexus.c \
++                            $(REFSW_VERSION)/nexus/default_nexus.c \
++                            $(REFSW_VERSION)/nexus/display_nexus_multi.c \
++                            $(REFSW_VERSION)/common/display_helpers.c \
++                            $(REFSW_VERSION)/common/memory_convert.c \
++                            $(REFSW_VERSION)/common/memory_drm.c \
++                            $(REFSW_VERSION)/common/memory_nexus.c \
++                            $(REFSW_VERSION)/common/sched_nexus.c \
++                            $(REFSW_VERSION)/common/display_framework.c \
++                            $(REFSW_VERSION)/common/display_interface.c \
++                            $(REFSW_VERSION)/common/event.c \
++                            $(REFSW_VERSION)/common/fence_interface.c \
++                            $(REFSW_VERSION)/common/perf_event.cpp \
++                            $(REFSW_VERSION)/common/queue.c \
++                            $(REFSW_VERSION)/common/ring_buffer.c \
++                            $(REFSW_VERSION)/common/buffer_interface.c \
++                            $(REFSW_VERSION)/common/buffer_interface_nexus.c \
++                            $(REFSW_VERSION)/common/swapchain.c
++else
++AM_CFLAGS += -DVCX=3
++AM_CFLAGS += \
++           -I${REFSW_VERSION}/nexus \
++           -I${REFSW_VERSION}/nexus/multi
++libwayland_egl_la_SOURCES += \
++                            $(REFSW_VERSION)/nexus/bitmap.cpp \
++                            $(REFSW_VERSION)/nexus/default_nexus.c \
++                            $(REFSW_VERSION)/common/packet_yv12.c \
++                            $(REFSW_VERSION)/common/packet_rgba.c \
++                            $(REFSW_VERSION)/common/perf_event.cpp \
++                            $(REFSW_VERSION)/common/nexus_surface_memory.c \
++                            $(REFSW_VERSION)/common/memory_nexus.c \
++                            $(REFSW_VERSION)/common/hardware_nexus.cpp \
++                            $(REFSW_VERSION)/common/autoclif.c \
++                            $(REFSW_VERSION)/nexus/multi/worker.cpp \
++                            $(REFSW_VERSION)/nexus/multi/windowinfo.cpp
++endif
++endif
++
++
+ if REFSW_latest
+    $(warning generic RDK is using latest Broadcom SDK version)
+    REFSW_VERSION=${PKG_CONFIG_SYSROOT_DIR}/usr/share/wayland-egl
+@@ -203,6 +344,9 @@
+ if !REFSW_16_2
+ if !REFSW_17_1
+ if !REFSW_17_3
++if !REFSW_18_1
++if !REFSW_18_2
++if !REFSW_18_3
+    $(warning Unsupported Broadcom SDK version - defaulting to 14.4 but expect wayland-egl-bnxs to be non-functional)
+    REFSW_VERSION=refsw14.4
+    libwayland_egl_la_SOURCES += \
+@@ -212,6 +356,9 @@
+                             $(REFSW_VERSION)/hardware_nexus.c
+    ROCKFORD_TOP="${REFSW_BASE}-rdk-linux/broadcom-refsw/unified-14.4-r0/rockford"
+ endif
++endif
++endif
++endif
+ endif                            
+ endif                            
+ endif

--- a/package/wayland-egl-bnxs/0006-wayland-egl-bnxs.19.1.patch
+++ b/package/wayland-egl-bnxs/0006-wayland-egl-bnxs.19.1.patch
@@ -1,0 +1,87 @@
+diff -auNrd git.orig/configure.ac git/configure.ac
+--- git.orig/configure.ac	2019-01-04 13:52:41.516975170 -0500
++++ git/configure.ac	2019-01-04 13:54:47.505290860 -0500
+@@ -159,6 +159,18 @@
+               [echo "refsw18_3 is disabled"])
+ AM_CONDITIONAL([REFSW_18_3], [test x$REFSW_18_3 = xtrue])
+ 
++AC_ARG_ENABLE([refsw19_1],
++              AS_HELP_STRING([--enable-refsw19_1],[enable refsw19_1 (default is no)]),
++              [
++                case "${enableval}" in
++                 yes) REFSW_19_1=true ;;
++                  no) AC_MSG_ERROR([refsw19_1 is disabled]) ;;
++                   *) AC_MSG_ERROR([bad value ${enableval} for --enable-refsw19_1]) ;;
++                esac
++              ],
++              [echo "refsw19_1 is disabled"])
++AM_CONDITIONAL([REFSW_19_1], [test x$REFSW_19_1 = xtrue])
++
+ AC_ARG_ENABLE([xg1v3_v3d],
+               AS_HELP_STRING([--enable-xg1v3_v3d],[enable xg1v3_v3d (default is no)]),
+               [
+diff -auNrd git.orig/Makefile.am git/Makefile.am
+--- git.orig/Makefile.am	2019-01-04 13:52:41.516975170 -0500
++++ git/Makefile.am	2019-01-04 13:59:46.653995026 -0500
+@@ -289,6 +289,45 @@
+ endif
+ endif
+ 
++if REFSW_19_1
++   $(warning generic RDK is using 19.1 Broadcom SDK version)
++   REFSW_VERSION=${PKG_CONFIG_SYSROOT_DIR}/usr/share/wayland-egl
++
++if ENABLE_VC5
++AM_CFLAGS += -DVCX=5
++libwayland_egl_la_SOURCES += \
++                            $(REFSW_VERSION)/nexus/display_nexus.c \
++                            $(REFSW_VERSION)/nexus/default_nexus.c \
++                            $(REFSW_VERSION)/nexus/display_nexus_multi.c \
++                            $(REFSW_VERSION)/common/debug_helper.cpp \
++                            $(REFSW_VERSION)/common/display_helpers.c \
++                            $(REFSW_VERSION)/common/display_framework.c \
++                            $(REFSW_VERSION)/common/display_interface.c \
++                            $(REFSW_VERSION)/common/event.c \
++                            $(REFSW_VERSION)/common/queue.c \
++                            $(REFSW_VERSION)/common/ring_buffer.c \
++                            $(REFSW_VERSION)/common/buffer_interface.c \
++                            $(REFSW_VERSION)/common/buffer_interface_nexus.c \
++                            $(REFSW_VERSION)/common/swapchain.c
++else
++AM_CFLAGS += -DVCX=3
++AM_CFLAGS += \
++           -I${REFSW_VERSION}/nexus \
++           -I${REFSW_VERSION}/nexus/multi
++libwayland_egl_la_SOURCES += \
++                            $(REFSW_VERSION)/nexus/bitmap.cpp \
++                            $(REFSW_VERSION)/nexus/default_nexus.c \
++                            $(REFSW_VERSION)/common/packet_yv12.c \
++                            $(REFSW_VERSION)/common/packet_rgba.c \
++                            $(REFSW_VERSION)/common/perf_event.cpp \
++                            $(REFSW_VERSION)/common/nexus_surface_memory.c \
++                            $(REFSW_VERSION)/common/memory_nexus.c \
++                            $(REFSW_VERSION)/common/hardware_nexus.cpp \
++                            $(REFSW_VERSION)/common/autoclif.c \
++                            $(REFSW_VERSION)/nexus/multi/worker.cpp \
++                            $(REFSW_VERSION)/nexus/multi/windowinfo.cpp
++endif
++endif
+ 
+ if REFSW_latest
+    $(warning generic RDK is using latest Broadcom SDK version)
+@@ -347,6 +387,7 @@
+ if !REFSW_18_1
+ if !REFSW_18_2
+ if !REFSW_18_3
++if !REFSW_19_1
+    $(warning Unsupported Broadcom SDK version - defaulting to 14.4 but expect wayland-egl-bnxs to be non-functional)
+    REFSW_VERSION=refsw14.4
+    libwayland_egl_la_SOURCES += \
+@@ -358,6 +399,7 @@
+ endif
+ endif
+ endif
++endif
+ endif
+ endif                            
+ endif                            

--- a/package/wayland-egl-bnxs/0007-wayland-egl-zorder.patch
+++ b/package/wayland-egl-bnxs/0007-wayland-egl-zorder.patch
@@ -1,0 +1,11 @@
+--- git/wayland-egl.cpp	2019-09-20 15:02:21.756694684 -0400
++++ git/wayland-egl.cpp.new	2019-09-20 15:02:01.767167775 -0400
+@@ -1192,7 +1192,7 @@
+          windowInfo.height= height;
+          windowInfo.stretch= true;
+          windowInfo.clientID= 0;
+-         windowInfo.zOrder= 10000000;
++         windowInfo.zOrder= 100;
+       
+          egl_window->nativeWindow= (EGLNativeWindowType)NXPL_CreateNativeWindow( &windowInfo );
+          if ( egl_window->nativeWindow )

--- a/package/wayland-egl-bnxs/wayland-egl-bnxs.mk
+++ b/package/wayland-egl-bnxs/wayland-egl-bnxs.mk
@@ -15,8 +15,13 @@ WAYLAND_EGL_BNXS_DEPENDENCIES = host-pkgconf host-autoconf wayland bcm-refsw
 WAYLAND_EGL_BNXS_CONF_OPTS = \
     --prefix=/usr/ \
     --disable-silent-rules \
-    --disable-dependency-tracking \
-    --enable-refsw_latest
+    --disable-dependency-tracking
+
+ifeq ($(BR2_PACKAGE_BCM_REFSW_19_1),y)
+WAYLAND_EGL_BNXS_CONF_OPTS += --enable-refsw19_1
+else
+WAYLAND_EGL_BNXS_CONF_OPTS += --enable-refsw_latest
+endif
 
 WAYLAND_EGL_BNXS_INCLUDES += \
 	-I$(STAGING_DIR)/usr/include/interface/khronos/include/bcg_abstract/ \
@@ -48,7 +53,7 @@ WAYLAND_EGL_BNXS_MAKE_ENV = \
     REFSW_VERSION="$(STAGING_DIR)/usr/share/wayland-egl" \
     PKG_CONFIG_SYSROOT_DIR="$(STAGING_DIR)"
 
-ifeq ($(BR2_PACKAGE_BCM_REFSW_18_2),y)
+ifeq ($(BR2_PACKAGE_BCM_REFSW_18_2)$(BR2_PACKAGE_BCM_REFSW_19_1),y)
 	WAYLAND_EGL_BNXS_CFLAGS += -DEMBEDDED_SETTOP_BOX
 	WAYLAND_EGL_BNXS_CXXFLAGS += -DEMBEDDED_SETTOP_BOX
 endif


### PR DESCRIPTION
Added required patch in bcm-refsw and wayland-egl-bnxs packages to build it with Wayland enabled case.
The changes are tested with below cases
1. bcm-refsw-19.1: Compositor as Wayland-Nexus: Cobalt/Spark/Netflix/WebKit: Working fine
2. bcm-refsw;19.1: Compositor as Nexus: just cross checked only using Webkit: Working fine
3. bcm-refsw;18.2: Compositor as Wayland-Nexus: Seen build error from wayland-egl-bnxs: it is already getting with master branch as well, so this has to be taken care another issue, will update JIRA
4. bcm-refsw;18.2:Compositor as Nexus: just cross checked only using Webkit: Working fine