### PR TITLE
Add support for gcc 7

### DIFF
--- a/Config.in
+++ b/Config.in
@@ -57,6 +57,11 @@ config BR2_HOST_GCC_AT_LEAST_6
 	default y if BR2_HOST_GCC_VERSION = "6"
 	select BR2_HOST_GCC_AT_LEAST_5
 
+config BR2_HOST_GCC_AT_LEAST_7
+	bool
+	default y if BR2_HOST_GCC_VERSION = "7"
+	select BR2_HOST_GCC_AT_LEAST_6
+
 # Hidden boolean selected by packages in need of Java in order to build
 # (example: xbmc)
 config BR2_NEEDS_HOST_JAVA


### PR DESCRIPTION
Due to the cascading nature of how the `BR2_HOST_GCC_AT_LEAST_X` variables are set, `BR2_HOST_GCC_AT_LEAST_4_8` is set to false on machines where the gcc version is higher than what is accounted for in the root config file (version 6). This PR does not fix the root cause of this issue, but it does add support for gcc 7. This issue will reappear when gcc 8 is released.