### PR TITLE
Ubuntu 21.10 buildfix

### DIFF
--- a/package/fakeroot/0002-libfakeroot.c-define-_STAT_VER-if-not-already-define.patch
+++ b/package/fakeroot/0002-libfakeroot.c-define-_STAT_VER-if-not-already-define.patch
@@ -1,0 +1,45 @@
+From 03bc0ee07fb6e293d081ffd8af1654788b434f6a Mon Sep 17 00:00:00 2001
+From: Ilya Lipnitskiy <ilya.lipnitskiy@gmail.com>
+Date: Thu, 11 Feb 2021 20:59:25 -0800
+Subject: [PATCH] libfakeroot.c: define _STAT_VER if not already defined
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+glibc 2.33 does does declare `_STAT_VER` anymore.
+
+Based on patch from Jan Pazdziora:
+https://lists.fedoraproject.org/archives/list/devel@lists.fedoraproject.org/message/SMQ3RYXEYTVZH6PLQMKNB3NM4XLPMNZO/
+
+Backported from: feda578ca3608b7fc9a28a3a91293611c0ef47b7
+
+Signed-off-by: Ilya Lipnitskiy <ilya.lipnitskiy@gmail.com>
+Signed-off-by: Jörg Krause <joerg.krause@embedded.rocks>
+---
+ libfakeroot.c | 10 ++++++++++
+ 1 file changed, 10 insertions(+)
+
+diff --git a/libfakeroot.c b/libfakeroot.c
+index 3e80e38..14cdbc4 100644
+--- a/libfakeroot.c
++++ b/libfakeroot.c
+@@ -90,6 +90,16 @@
+ #define SEND_GET_XATTR64(a,b,c) send_get_xattr64(a,b)
+ #endif
+ 
++#ifndef _STAT_VER
++ #if defined (__aarch64__)
++  #define _STAT_VER 0
++ #elif defined (__x86_64__)
++  #define _STAT_VER 1
++ #else
++  #define _STAT_VER 3
++ #endif
++#endif
++
+ /*
+    These INT_* (which stands for internal) macros should always be used when
+    the fakeroot library owns the storage of the stat variable.
+-- 
+2.30.1
+

--- a/package/fakeroot/0003-libfakeroot.c-add-wrappers-for-new-glibc-2.33-symbol.patch
+++ b/package/fakeroot/0003-libfakeroot.c-add-wrappers-for-new-glibc-2.33-symbol.patch
@@ -1,0 +1,80 @@
+From feda578ca3608b7fc9a28a3a91293611c0ef47b7 Mon Sep 17 00:00:00 2001
+From: Ilya Lipnitskiy <ilya.lipnitskiy@gmail.com>
+Date: Thu, 11 Feb 2021 21:00:04 -0800
+Subject: [PATCH] libfakeroot.c: add wrappers for new glibc 2.33+ symbols
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+This patch add wrappers for newly exported symbols in glibc 2.33.
+
+Backported from: feda578ca3608b7fc9a28a3a91293611c0ef47b7
+
+Signed-off-by: Ilya Lipnitskiy <ilya.lipnitskiy@gmail.com>
+Signed-off-by: Jörg Krause <joerg.krause@embedded.rocks>
+---
+ libfakeroot.c | 48 ++++++++++++++++++++++++++++++++++++++++++++++++
+ 1 file changed, 48 insertions(+)
+
+diff --git a/libfakeroot.c b/libfakeroot.c
+index 14cdbc4..d75c51f 100644
+--- a/libfakeroot.c
++++ b/libfakeroot.c
+@@ -1352,6 +1352,54 @@ int renameat(int olddir_fd, const char *oldpath,
+ #endif /* HAVE_FSTATAT */
+ 
+ 
++#if defined(__GLIBC__) && __GLIBC_PREREQ(2,33)
++/* Glibc 2.33 exports symbols for these functions in the shared lib */
++  int lstat(const char *file_name, struct stat *statbuf) {
++     return WRAP_LSTAT LSTAT_ARG(_STAT_VER, file_name, statbuf);
++  }
++  int stat(const char *file_name, struct stat *st) {
++     return WRAP_STAT STAT_ARG(_STAT_VER, file_name, st);
++  }
++  int fstat(int fd, struct stat *st) {
++     return WRAP_FSTAT FSTAT_ARG(_STAT_VER, fd, st);
++  }
++
++  #ifdef HAVE_FSTATAT
++    int fstatat(int dir_fd, const char *path, struct stat *st, int flags) {
++       return WRAP_FSTATAT FSTATAT_ARG(_STAT_VER, dir_fd, path, st, flags);
++    }
++  #endif
++
++  #ifdef STAT64_SUPPORT
++    int lstat64(const char *file_name, struct stat64 *st) {
++       return WRAP_LSTAT64 LSTAT64_ARG(_STAT_VER, file_name, st);
++    }
++    int stat64(const char *file_name, struct stat64 *st) {
++       return WRAP_STAT64 STAT64_ARG(_STAT_VER, file_name, st);
++    }
++    int fstat64(int fd, struct stat64 *st) {
++       return WRAP_FSTAT64 FSTAT64_ARG(_STAT_VER, fd, st);
++    }
++
++    #ifdef HAVE_FSTATAT
++      int fstatat64(int dir_fd, const char *path, struct stat64 *st, int flags) {
++	 return WRAP_FSTATAT64 FSTATAT64_ARG(_STAT_VER, dir_fd, path, st, flags);
++      }
++    #endif
++  #endif
++
++  int mknod(const char *pathname, mode_t mode, dev_t dev) {
++     return WRAP_MKNOD MKNOD_ARG(_STAT_VER, pathname, mode, &dev);
++  }
++
++  #if defined(HAVE_FSTATAT) && defined(HAVE_MKNODAT)
++    int mknodat(int dir_fd, const char *pathname, mode_t mode, dev_t dev) {
++       return WRAP_MKNODAT MKNODAT_ARG(_STAT_VER, dir_fd, pathname, mode, &dev);
++    }
++  #endif
++#endif /* GLIBC_PREREQ */
++
++
+ #ifdef FAKEROOT_FAKENET
+ pid_t fork(void)
+ {
+-- 
+2.30.1
+

--- a/package/fakeroot/0004-configure.ac-fix-__xmknod-at-pointer-argument.patch
+++ b/package/fakeroot/0004-configure.ac-fix-__xmknod-at-pointer-argument.patch
@@ -1,0 +1,66 @@
+From 432dd46e662772020306a2ce8b1be38321697e69 Mon Sep 17 00:00:00 2001
+From: Ilya Lipnitskiy <ilya.lipnitskiy@gmail.com>
+Date: Sat, 13 Feb 2021 19:32:08 -0800
+Subject: [PATCH] configure.ac: fix __xmknod{,at} pointer argument
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Switch default to assume * and not the absence of *.
+
+On glibc 2.33+, there is no definition for these functions in header
+files, so the compile test doesn't work. But, we can default to using
+the pointer (as is the case with newer glibc), and use the header file
+on older platforms to fail the test and use no pointer.
+
+Backported from: c3eebec293e35b997bb46c22fb5a4e114afb5e7f
+
+Signed-off-by: Ilya Lipnitskiy <ilya.lipnitskiy@gmail.com>
+Signed-off-by: Jörg Krause <joerg.krause@embedded.rocks>
+---
+ configure.ac | 16 ++++++++--------
+ 1 file changed, 8 insertions(+), 8 deletions(-)
+
+diff --git a/configure.ac b/configure.ac
+index 73415d2..d85566f 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -183,13 +183,13 @@ AC_MSG_CHECKING([for type of arg of __xmknod])
+   ]], [[
+        int __xmknod  ( int ver,
+                        const char *pathname ,
+-                       mode_t  mode ,  dev_t dev);
++                       mode_t  mode ,  dev_t *dev);
+   ]])],[
+-   AC_DEFINE(XMKNOD_FRTH_ARG,)
+-   AC_MSG_RESULT([no extra *])
+-  ],[
+    AC_DEFINE(XMKNOD_FRTH_ARG,[*])
+    AC_MSG_RESULT([needs *])
++  ],[
++   AC_DEFINE(XMKNOD_FRTH_ARG,)
++   AC_MSG_RESULT([no extra *])
+ 
+   ])
+ 
+@@ -210,13 +210,13 @@ AC_MSG_CHECKING([for type of arg of __xmknodat])
+        int __xmknodat  ( int ver,
+                          int dirfd,
+                          const char *pathname ,
+-                         mode_t  mode ,  dev_t dev);
++                         mode_t  mode ,  dev_t *dev);
+   ]])],[
+-   AC_DEFINE(XMKNODAT_FIFTH_ARG,)
+-   AC_MSG_RESULT([no extra *])
+-  ],[
+    AC_DEFINE(XMKNODAT_FIFTH_ARG,[*])
+    AC_MSG_RESULT([needs *])
++  ],[
++   AC_DEFINE(XMKNODAT_FIFTH_ARG,)
++   AC_MSG_RESULT([no extra *])
+ 
+   ])
+ 
+-- 
+2.30.1
+

--- a/package/fakeroot/fakeroot.mk
+++ b/package/fakeroot/fakeroot.mk
@@ -15,7 +15,7 @@ HOST_FAKEROOT_DEPENDENCIES = host-acl
 HOST_FAKEROOT_CONF_ENV = \
 	ac_cv_header_sys_capability_h=no \
 	ac_cv_func_capset=no
-# 0003-Select-TCP-when-lack-of-SYSV-IPC.patch touches configure.ac
+# patching configure.ac in patch 0003
 HOST_FAKEROOT_AUTORECONF = YES
 FAKEROOT_LICENSE = GPL-3.0+
 FAKEROOT_LICENSE_FILES = COPYING

--- a/package/gcc/9.2.0/0004-gcc-Makefile.in-move-SELFTEST_DEPS-before-including-.patch
+++ b/package/gcc/9.2.0/0004-gcc-Makefile.in-move-SELFTEST_DEPS-before-including-.patch
@@ -1,0 +1,81 @@
+From 811c8d628045c3d248144fc560a4bf80209ca16e Mon Sep 17 00:00:00 2001
+From: Romain Naour <romain.naour@gmail.com>
+Date: Thu, 21 May 2020 15:58:02 +0200
+Subject: [PATCH] gcc/Makefile.in: move SELFTEST_DEPS before including language
+ makefile fragments
+
+As reported by several Buildroot users [1][2][3], the gcc build
+may fail while running selftests makefile target.
+
+The problem only occurs when ccache is used with gcc 9 and 10,
+probably due to a race condition.
+
+While debuging with "make -p" we can notice that s-selftest-c target
+contain only "cc1" as dependency instead of cc1 and SELFTEST_DEPS [4].
+
+  s-selftest-c: cc1
+
+While the build is failing, the s-selftest-c dependencies recipe is
+still running and reported as a bug by make.
+
+  "Dependencies recipe running (THIS IS A BUG)."
+
+A change [5] in gcc 9 seems to introduce the problem since we can't
+reproduce this problem with gcc 8.
+
+As suggested by Yann E. MORIN [6], move SELFTEST_DEPS before
+including language makefile fragments.
+
+With the fix applied, the s-seltest-c dependency contains
+SELFTEST_DEPS value.
+
+  s-selftest-c: cc1 xgcc specs stmp-int-hdrs ../../gcc/testsuite/selftests
+
+[1] http://lists.busybox.net/pipermail/buildroot/2020-May/282171.html
+[2] http://lists.busybox.net/pipermail/buildroot/2020-May/282766.html
+[3] https://github.com/cirosantilli/linux-kernel-module-cheat/issues/108
+[4] https://gcc.gnu.org/git/?p=gcc.git;a=blob;f=gcc/c/Make-lang.in;h=bfae6fd2549c4f728816cd355fa9739dcc08fcde;hb=033eb5671769a4c681a44aad08a454e667e08502#l120
+[5] https://gcc.gnu.org/git/?p=gcc.git;a=commitdiff;h=033eb5671769a4c681a44aad08a454e667e08502
+[6] http://lists.busybox.net/pipermail/buildroot/2020-May/283213.html
+
+Upstream status: https://gcc.gnu.org/pipermail/gcc-patches/2020-May/546248.html
+
+Signed-off-by: Romain Naour <romain.naour@gmail.com>
+Cc: Ben Dakin-Norris <ben.dakin-norris@navtechradar.com>
+Cc: Maxim Kochetkov <fido_max@inbox.ru>
+Cc: Thomas Petazzoni <thomas.petazzoni@bootlin.com>
+Cc: Yann E. MORIN <yann.morin.1998@free.fr>
+Cc: Cc: David Malcolm <dmalcolm@gcc.gnu.org>
+---
+This patch should be backported to gcc 10 and gcc 9.
+---
+ gcc/Makefile.in | 6 ++++--
+ 1 file changed, 4 insertions(+), 2 deletions(-)
+
+diff --git a/gcc/Makefile.in b/gcc/Makefile.in
+index abae872cd63..e2ef3c46afc 100644
+--- a/gcc/Makefile.in
++++ b/gcc/Makefile.in
+@@ -1686,6 +1686,10 @@ $(FULL_DRIVER_NAME): ./xgcc
+ 	rm -f $@
+ 	$(LN_S) $< $@
+ 
++# SELFTEST_DEPS need to be set before including language makefile fragments.
++# Otherwise $(SELFTEST_DEPS) is empty when used from various <LANG>/Make-lang.in.
++SELFTEST_DEPS = $(GCC_PASSES) stmp-int-hdrs $(srcdir)/testsuite/selftests
++
+ #
+ # Language makefile fragments.
+ 
+@@ -1950,8 +1954,6 @@ DEVNULL=$(if $(findstring mingw,$(build)),nul,/dev/null)
+ SELFTEST_FLAGS = -nostdinc $(DEVNULL) -S -o $(DEVNULL) \
+ 	-fself-test=$(srcdir)/testsuite/selftests
+ 
+-SELFTEST_DEPS = $(GCC_PASSES) stmp-int-hdrs $(srcdir)/testsuite/selftests
+-
+ # Run the selftests during the build once we have a driver and the frontend,
+ # so that self-test failures are caught as early as possible.
+ # Use "s-selftest-FE" to ensure that we only run the selftests if the
+-- 
+2.25.4
+

--- a/package/m4/0003-c-stack-stop-using-SIGSTKSZ.patch
+++ b/package/m4/0003-c-stack-stop-using-SIGSTKSZ.patch
@@ -1,0 +1,106 @@
+c-stack: stop using SIGSTKSZ
+
+It’s been proposed to stop making SIGSTKSZ an integer constant:
+https://sourceware.org/pipermail/libc-alpha/2020-September/118028.html
+Also, using SIGSTKSZ in #if did not conform to current POSIX.
+Also, avoiding SIGSTKSZ makes the code simpler and easier to grok.
+* lib/c-stack.c (SIGSTKSZ): Remove.
+(alternate_signal_stack): Now a 64 KiB array, for simplicity.
+All uses changed.
+
+[Retrieved (and backported) from:
+https://git.savannah.gnu.org/cgit/gnulib.git/patch/?id=f9e2b20a12a230efa30f1d479563ae07d276a94b]
+Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>
+
+diff -Nura m4-1.4.18.orig/lib/c-stack.c m4-1.4.18/lib/c-stack.c
+--- m4-1.4.18.orig/lib/c-stack.c	2021-04-11 19:12:14.086494029 +0200
++++ m4-1.4.18/lib/c-stack.c	2021-04-11 19:48:46.316862760 +0200
+@@ -50,15 +50,16 @@
+ #if ! HAVE_STACK_T && ! defined stack_t
+ typedef struct sigaltstack stack_t;
+ #endif
+-#ifndef SIGSTKSZ
+-# define SIGSTKSZ 16384
+-#elif HAVE_LIBSIGSEGV && SIGSTKSZ < 16384
+-/* libsigsegv 2.6 through 2.8 have a bug where some architectures use
+-   more than the Linux default of an 8k alternate stack when deciding
+-   if a fault was caused by stack overflow.  */
+-# undef SIGSTKSZ
+-# define SIGSTKSZ 16384
+-#endif
++
++/* Storage for the alternate signal stack.
++   64 KiB is not too large for Gnulib-using apps, and is large enough
++   for all known platforms.  Smaller sizes may run into trouble.
++   For example, libsigsegv 2.6 through 2.8 have a bug where some
++   architectures use more than the Linux default of an 8 KiB alternate
++   stack when deciding if a fault was caused by stack overflow.  */
++static max_align_t alternate_signal_stack[(64 * 1024
++                                           + sizeof (max_align_t) - 1)
++                                          / sizeof (max_align_t)];
+ 
+ #include <stdlib.h>
+ #include <string.h>
+@@ -128,19 +129,6 @@
+ #if (HAVE_SIGALTSTACK && HAVE_DECL_SIGALTSTACK \
+      && HAVE_STACK_OVERFLOW_HANDLING) || HAVE_LIBSIGSEGV
+ 
+-/* Storage for the alternate signal stack.  */
+-static union
+-{
+-  char buffer[SIGSTKSZ];
+-
+-  /* These other members are for proper alignment.  There's no
+-     standard way to guarantee stack alignment, but this seems enough
+-     in practice.  */
+-  long double ld;
+-  long l;
+-  void *p;
+-} alternate_signal_stack;
+-
+ static void
+ null_action (int signo __attribute__ ((unused)))
+ {
+@@ -205,8 +193,8 @@
+ 
+   /* Always install the overflow handler.  */
+   if (stackoverflow_install_handler (overflow_handler,
+-                                     alternate_signal_stack.buffer,
+-                                     sizeof alternate_signal_stack.buffer))
++                                     alternate_signal_stack,
++                                     sizeof alternate_signal_stack))
+     {
+       errno = ENOTSUP;
+       return -1;
+@@ -279,14 +267,14 @@
+   stack_t st;
+   struct sigaction act;
+   st.ss_flags = 0;
++  st.ss_sp = alternate_signal_stack;
++  st.ss_size = sizeof alternate_signal_stack;
+ # if SIGALTSTACK_SS_REVERSED
+   /* Irix mistakenly treats ss_sp as the upper bound, rather than
+      lower bound, of the alternate stack.  */
+-  st.ss_sp = alternate_signal_stack.buffer + SIGSTKSZ - sizeof (void *);
+-  st.ss_size = sizeof alternate_signal_stack.buffer - sizeof (void *);
+-# else
+-  st.ss_sp = alternate_signal_stack.buffer;
+-  st.ss_size = sizeof alternate_signal_stack.buffer;
++  st.ss_size -= sizeof (void *);
++  char *ss_sp = st.ss_sp;
++  st.ss_sp = ss_sp + st.ss_size;
+ # endif
+   r = sigaltstack (&st, NULL);
+   if (r != 0)
+diff -Nura m4-1.4.18.orig/lib/c-stack.h m4-1.4.18/lib/c-stack.h
+--- m4-1.4.18.orig/lib/c-stack.h	2021-04-11 19:12:14.098494042 +0200
++++ m4-1.4.18/lib/c-stack.h	2021-04-11 19:17:42.138848378 +0200
+@@ -34,7 +34,7 @@
+    A null ACTION acts like an action that does nothing.
+ 
+    ACTION must be async-signal-safe.  ACTION together with its callees
+-   must not require more than SIGSTKSZ bytes of stack space.  Also,
++   must not require more than 64 KiB bytes of stack space.  Also,
+    ACTION should not call longjmp, because this implementation does
+    not guarantee that it is safe to return to the original stack.
+ 


### PR DESCRIPTION
These were the patches that I had to cherry-pick to build some host packages:

* m4
* fakeroot
* gcc

Could not go through the end of the WPE-related recipes, due to issues accessing some repos.