### PR TITLE
[Disney] Add ability to build SHIELDs from sources

### DIFF
--- a/package/disney/Config.in
+++ b/package/disney/Config.in
@@ -59,7 +59,7 @@ menu "Test tools"
         Disney+ tests
 
     config BR2_PACKAGE_DISNEY_TOOLING_SHIELD_AGENT
-    depends on BR2_PACKAGE_DISNEY_TOOLING
+    select BR2_PACKAGE_DISNEY_TOOLING
     bool "Build SHIELD Agent"
     default n
     help
@@ -68,7 +68,7 @@ menu "Test tools"
         depends on !BR2_PACKAGE_DISNEY_TOOLING
 
     config BR2_PACKAGE_DISNEY_TOOLING_SHIELD_EXTENSION
-    depends on BR2_PACKAGE_DISNEY_TOOLING
+    select BR2_PACKAGE_DISNEY_TOOLING
     bool "Build SHIELD Extension"
     default n
     help

--- a/package/disney/Config.in
+++ b/package/disney/Config.in
@@ -51,15 +51,38 @@ config BR2_PACKAGE_DISNEY_LINK_EXECUTABLE
     help
         Disney+ Merlin executable
 
-config BR2_PACKAGE_DISNEY_LINK_TESTS
+menu "Test tools"
+    config BR2_PACKAGE_DISNEY_LINK_TESTS
     bool "Build ADK test suite"
     default n
     help
         Disney+ tests
+
+    config BR2_PACKAGE_DISNEY_TOOLING_SHIELD_AGENT
+    depends on BR2_PACKAGE_DISNEY_TOOLING
+    bool "Build SHIELD Agent"
+    default n
+    help
+        Build SHIELD Agent (Development tool)
+    comment "SHIELD Agent depens on disney-tooling"
+        depends on !BR2_PACKAGE_DISNEY_TOOLING
+
+    config BR2_PACKAGE_DISNEY_TOOLING_SHIELD_EXTENSION
+    depends on BR2_PACKAGE_DISNEY_TOOLING
+    bool "Build SHIELD Extension"
+    default n
+    help
+        Build SHIELD Extension (Integration test tool)
+    comment "SHIELD Extension depens on disney-tooling"
+        depends on !BR2_PACKAGE_DISNEY_TOOLING
+
+endmenu
+
 
 endmenu
 endif
 
 source "package/disney/disney-uma/Config.in"
 source "package/disney/disney-libopenssl/Config.in"
+source "package/disney/disney-tooling/Config.in"
 

--- a/package/disney/disney-tooling/Config.in
+++ b/package/disney/disney-tooling/Config.in
@@ -1,4 +1,5 @@
 config BR2_PACKAGE_DISNEY_TOOLING
     bool "disney-tooling"
+    default n
     help
         Disney+ Tooling

--- a/package/disney/disney-tooling/Config.in
+++ b/package/disney/disney-tooling/Config.in
@@ -1,0 +1,4 @@
+config BR2_PACKAGE_DISNEY_TOOLING
+    bool "disney-tooling"
+    help
+        Disney+ Tooling

--- a/package/disney/disney-tooling/disney-tooling.mk
+++ b/package/disney/disney-tooling/disney-tooling.mk
@@ -1,0 +1,75 @@
+################################################################################
+#
+# Disney+ tooling
+#
+################################################################################
+
+DISNEY_TOOLING_VERSION = 30f43c24c6f16394bef1192b5a48e252fec40fe2
+DISNEY_TOOLING_SITE = git@github.com:Metrological/disneyplus-tooling.git
+DISNEY_TOOLING_SITE_METHOD = git
+DISNEY_TOOLING_LICENSE = PROPRIETARY
+DISNEY_TOOLING_INSTALL_STAGING = NO
+DISNEY_TOOLING_DEPENDENCIES = disney
+
+_DISNEY_EXTRACT_DIR = $(BUILD_DIR)/disney-$(DISNEY_VERSION)
+
+define DISNEY_TOOLING_CONFIGURE_CMDS
+       ln -sf $(@D)/shield-agent ${_DISNEY_EXTRACT_DIR}
+       cd $(_DISNEY_EXTRACT_DIR) && CC="$(TARGET_CC)" CXX="$(TARGET_CXX)" GCC_PREFIX="$(TARGET_CROSS)" PLATFORM="$(_DISNEY_TARGET_PLATFORM)" ARCH="$(KERNEL_ARCH)" \
+          ./premake5 --verbose --file=shield-agent/premake5.lua --target=$(_DISNEY_TARGET_NAME) gmake2
+endef
+
+ifeq ($(BR2_PACKAGE_DISNEY_TOOLING_SHIELD_AGENT),y)
+define _DISNEY_TOOLING_BUILD_SHIELD_AGENT
+       @echo ----------------------------------------------------------------------------
+       @echo Building Disney SHIELD Agent
+       @echo ----------------------------------------------------------------------------
+       cd $(_DISNEY_EXTRACT_DIR)/build && make shield-agent config=$(_DISNEY_BUILD_CONFIG) $(_DISNEY_VERBOSE)
+endef
+endif
+
+ifeq ($(BR2_PACKAGE_DISNEY_TOOLING_SHIELD_EXTENSION),y)
+define _DISNEY_TOOLING_BUILD_SHIELD_EXTENSION
+       @echo ----------------------------------------------------------------------------
+       @echo Building Disney SHIELD Extension
+       @echo ----------------------------------------------------------------------------
+       cd $(_DISNEY_EXTRACT_DIR)/build && make shield-agent-extension morgana config=$(_DISNEY_BUILD_CONFIG) $(_DISNEY_VERBOSE)
+endef
+endif
+
+define DISNEY_TOOLING_BUILD_CMDS
+       $(call _DISNEY_TOOLING_BUILD_SHIELD_AGENT)
+       $(call _DISNEY_TOOLING_BUILD_SHIELD_EXTENSION)
+endef
+
+
+ifeq ($(BR2_PACKAGE_DISNEY_TOOLING_SHIELD_AGENT),y)
+define _DISNEY_TOOLING_INSTALL_SHIELD_AGENT
+       @echo "Installing shield-agent executable"
+       $(INSTALL) -D -m 0755 $(_DISNEY_EXTRACT_DIR)/build/bin/$(_DISNEY_TARGET_PLATFORM)/$(_DISNEY_BUILD_TYPE)/shield-agent $(TARGET_DIR)/usr/bin/shield-agent
+endef
+endif
+
+ifeq ($(BR2_PACKAGE_DISNEY_TOOLING_SHIELD_EXTENSION),y)
+define _DISNEY_TOOLING_INSTALL_SHIELD_EXTENSION
+       @echo "Installing Extensions"
+       cp -R $(_DISNEY_EXTRACT_DIR)/build/bin/$(_DISNEY_TARGET_PLATFORM)/$(_DISNEY_BUILD_TYPE)/extensions $(TARGET_DIR)$(_DISNEY_DATA_DIR)/shield_runtime/extensions
+       @echo "Installing morgana executable"
+       $(INSTALL) -D -m 0755 $(_DISNEY_EXTRACT_DIR)/build/bin/$(_DISNEY_TARGET_PLATFORM)/$(_DISNEY_BUILD_TYPE)/morgana $(TARGET_DIR)/usr/bin/morgana
+endef
+endif
+
+define _DISNEY_TOOLING_INSTALL
+       @echo "Installing shield_runtime"
+       cp -R $(_DISNEY_EXTRACT_DIR)/shield_runtime $(TARGET_DIR)$(_DISNEY_DATA_DIR)
+       cp -R $(_DISNEY_EXTRACT_DIR)/build/shield_runtime/shield_agent_data/assets/dy_lib_tests  $(TARGET_DIR)$(_DISNEY_DATA_DIR)/shield_runtime/shield_agent_data/assets
+       $(call _DISNEY_TOOLING_INSTALL_SHIELD_AGENT)
+       $(call _DISNEY_TOOLING_INSTALL_SHIELD_EXTENSION)
+endef
+
+define DISNEY_TOOLING_INSTALL_TARGET_CMDS
+       $(call _DISNEY_TOOLING_INSTALL)
+endef
+
+
+$(eval $(generic-package))

--- a/package/disney/disney-tooling/disney-tooling.mk
+++ b/package/disney/disney-tooling/disney-tooling.mk
@@ -11,72 +11,84 @@ DISNEY_TOOLING_LICENSE = PROPRIETARY
 DISNEY_TOOLING_INSTALL_STAGING = NO
 DISNEY_TOOLING_DEPENDENCIES = disney
 
-_DISNEY_EXTRACT_DIR = $(BUILD_DIR)/disney-$(DISNEY_VERSION)
+# Shields need to be built from the ADK sources.
+# A link is created from the shield-agent (this build dir) to the ADK build directory.
+# That way shield-agent and extension can be properly configured using configuration variables from the ADK
+# and a proper premake file can be selected. Then it is built using generated make files inside the ADK build directory.
+_DISNEY_BUILD_DIR = $(BUILD_DIR)/disney-$(DISNEY_VERSION)
+
+
+_DISNEY_TOOLING_CONFIGURE_FLAGS = --verbose \
+								  --file=shield-agent/premake5.lua \
+								  --target=$(_DISNEY_TARGET_NAME)
+
 
 ifeq ($(BR2_PACKAGE_DISNEY_PLAYER_UMA),y)
-_DISNEY_PLAYER = nve-shared
-_DISNEY_CURL_HTTP = --curl-http2
 DISNEY_TOOLING_DEPENDENCIES += disney-uma
+_DISNEY_TOOLING_CONFIGURE_FLAGS += --player=$(_DISNEY_PLAYER) $(_DISNEY_CURL_HTTP)
 endif
 
 define DISNEY_TOOLING_CONFIGURE_CMDS
-       ln -sf $(@D)/shield-agent ${_DISNEY_EXTRACT_DIR}
-       cd $(_DISNEY_EXTRACT_DIR) && CC="$(TARGET_CC)" CXX="$(TARGET_CXX)" GCC_PREFIX="$(TARGET_CROSS)" PLATFORM="$(_DISNEY_TARGET_PLATFORM)" \
-          ARCH="$(KERNEL_ARCH)" SSL_VERSION="$(DISNEY_LIBOPENSSL_SO_VERSION)" SYSINCLUDEDIR="$(STAGING_DIR)/usr/include" \
-              SYSLIBDIR="$(STAGING_DIR)/usr/lib" \
-                 ./premake5 --verbose --file=shield-agent/premake5.lua --target=$(_DISNEY_TARGET_NAME) --player=$(_DISNEY_PLAYER) $(_DISNEY_CURL_HTTP) gmake2
+    ln -sf $(@D)/shield-agent ${_DISNEY_BUILD_DIR}
+    cd "$(_DISNEY_BUILD_DIR)" && \
+		CC="$(TARGET_CC)" CXX="$(TARGET_CXX)" GCC_PREFIX="$(TARGET_CROSS)" PLATFORM="$(_DISNEY_TARGET_PLATFORM)" \
+    	ARCH="$(KERNEL_ARCH)" SSL_VERSION="$(DISNEY_LIBOPENSSL_SO_VERSION)" SYSINCLUDEDIR="$(STAGING_DIR)/usr/include" \
+    	SYSLIBDIR="$(STAGING_DIR)/usr/lib" \
+		./premake5 $(_DISNEY_TOOLING_CONFIGURE_FLAGS) gmake2
 endef
 
 ifeq ($(BR2_PACKAGE_DISNEY_TOOLING_SHIELD_AGENT),y)
 define _DISNEY_TOOLING_BUILD_SHIELD_AGENT
-       @echo ----------------------------------------------------------------------------
-       @echo Building Disney SHIELD Agent
-       @echo ----------------------------------------------------------------------------
-       cd $(_DISNEY_EXTRACT_DIR)/build && make shield-agent config=$(_DISNEY_BUILD_CONFIG) $(_DISNEY_VERBOSE)
+    @echo ----------------------------------------------------------------------------
+    @echo Building Disney SHIELD Agent
+    @echo ----------------------------------------------------------------------------
+    cd "$(_DISNEY_BUILD_DIR)/build" && \
+		make shield-agent config=$(_DISNEY_BUILD_CONFIG) $(_DISNEY_VERBOSE)
 endef
 endif
 
 ifeq ($(BR2_PACKAGE_DISNEY_TOOLING_SHIELD_EXTENSION),y)
 define _DISNEY_TOOLING_BUILD_SHIELD_EXTENSION
-       @echo ----------------------------------------------------------------------------
-       @echo Building Disney SHIELD Extension
-       @echo ----------------------------------------------------------------------------
-       cd $(_DISNEY_EXTRACT_DIR)/build && make shield-agent-extension morgana config=$(_DISNEY_BUILD_CONFIG) $(_DISNEY_VERBOSE)
+    @echo ----------------------------------------------------------------------------
+    @echo Building Disney SHIELD Extension
+    @echo ----------------------------------------------------------------------------
+    cd "$(_DISNEY_BUILD_DIR)/build" && \
+		make shield-agent-extension morgana config=$(_DISNEY_BUILD_CONFIG) $(_DISNEY_VERBOSE)
 endef
 endif
 
 define DISNEY_TOOLING_BUILD_CMDS
-       $(call _DISNEY_TOOLING_BUILD_SHIELD_AGENT)
-       $(call _DISNEY_TOOLING_BUILD_SHIELD_EXTENSION)
+	$(call _DISNEY_TOOLING_BUILD_SHIELD_AGENT)
+	$(call _DISNEY_TOOLING_BUILD_SHIELD_EXTENSION)
 endef
 
 
 ifeq ($(BR2_PACKAGE_DISNEY_TOOLING_SHIELD_AGENT),y)
 define _DISNEY_TOOLING_INSTALL_SHIELD_AGENT
-       @echo "Installing shield-agent executable"
-       $(INSTALL) -D -m 0755 $(_DISNEY_EXTRACT_DIR)/build/bin/$(_DISNEY_TARGET_PLATFORM)/$(_DISNEY_BUILD_TYPE)/shield-agent $(TARGET_DIR)/usr/bin/shield-agent
+    @echo "Installing shield-agent executable"
+    $(INSTALL) -D -m 0755 "$(_DISNEY_BUILD_DIR)/build/bin/$(_DISNEY_TARGET_PLATFORM)/$(_DISNEY_BUILD_TYPE)/shield-agent" "$(TARGET_DIR)/usr/bin/shield-agent"
 endef
 endif
 
 ifeq ($(BR2_PACKAGE_DISNEY_TOOLING_SHIELD_EXTENSION),y)
 define _DISNEY_TOOLING_INSTALL_SHIELD_EXTENSION
-       @echo "Installing Extensions"
-       cp -R $(_DISNEY_EXTRACT_DIR)/build/bin/$(_DISNEY_TARGET_PLATFORM)/$(_DISNEY_BUILD_TYPE)/extensions $(TARGET_DIR)$(_DISNEY_DATA_DIR)/shield_runtime/extensions
-       @echo "Installing morgana executable"
-       $(INSTALL) -D -m 0755 $(_DISNEY_EXTRACT_DIR)/build/bin/$(_DISNEY_TARGET_PLATFORM)/$(_DISNEY_BUILD_TYPE)/morgana $(TARGET_DIR)/usr/bin/morgana
+    @echo "Installing Extensions"
+    cp -R "$(_DISNEY_BUILD_DIR)/build/bin/$(_DISNEY_TARGET_PLATFORM)/$(_DISNEY_BUILD_TYPE)/extensions" "$(TARGET_DIR)$(_DISNEY_DATA_DIR)/shield_runtime/extensions"
+    @echo "Installing morgana executable"
+    $(INSTALL) -D -m 0755 "$(_DISNEY_BUILD_DIR)/build/bin/$(_DISNEY_TARGET_PLATFORM)/$(_DISNEY_BUILD_TYPE)/morgana" "$(TARGET_DIR)/usr/bin/morgana"
 endef
 endif
 
 define _DISNEY_TOOLING_INSTALL
-       @echo "Installing shield_runtime"
-       cp -R $(_DISNEY_EXTRACT_DIR)/shield_runtime $(TARGET_DIR)$(_DISNEY_DATA_DIR)
-       cp -R $(_DISNEY_EXTRACT_DIR)/build/shield_runtime/shield_agent_data/assets/dy_lib_tests  $(TARGET_DIR)$(_DISNEY_DATA_DIR)/shield_runtime/shield_agent_data/assets
-       $(call _DISNEY_TOOLING_INSTALL_SHIELD_AGENT)
-       $(call _DISNEY_TOOLING_INSTALL_SHIELD_EXTENSION)
+    @echo "Installing shield_runtime"
+    cp -R "$(_DISNEY_BUILD_DIR)/shield_runtime" "$(TARGET_DIR)$(_DISNEY_DATA_DIR)"
+    cp -R "$(_DISNEY_BUILD_DIR)/build/shield_runtime/shield_agent_data/assets/dy_lib_tests" "$(TARGET_DIR)$(_DISNEY_DATA_DIR)/shield_runtime/shield_agent_data/assets"
+    $(call _DISNEY_TOOLING_INSTALL_SHIELD_AGENT)
+    $(call _DISNEY_TOOLING_INSTALL_SHIELD_EXTENSION)
 endef
 
 define DISNEY_TOOLING_INSTALL_TARGET_CMDS
-       $(call _DISNEY_TOOLING_INSTALL)
+    $(call _DISNEY_TOOLING_INSTALL)
 endef
 
 

--- a/package/disney/disney-tooling/disney-tooling.mk
+++ b/package/disney/disney-tooling/disney-tooling.mk
@@ -73,7 +73,7 @@ endif
 ifeq ($(BR2_PACKAGE_DISNEY_TOOLING_SHIELD_EXTENSION),y)
 define _DISNEY_TOOLING_INSTALL_SHIELD_EXTENSION
     @echo "Installing Extensions"
-    cp -R "$(_DISNEY_BUILD_DIR)/build/bin/$(_DISNEY_TARGET_PLATFORM)/$(_DISNEY_BUILD_TYPE)/extensions" "$(TARGET_DIR)$(_DISNEY_DATA_DIR)/shield_runtime/extensions"
+    rsync -a "$(_DISNEY_BUILD_DIR)/build/bin/$(_DISNEY_TARGET_PLATFORM)/$(_DISNEY_BUILD_TYPE)/extensions" "$(TARGET_DIR)$(_DISNEY_DATA_DIR)/shield_runtime/"
     @echo "Installing morgana executable"
     $(INSTALL) -D -m 0755 "$(_DISNEY_BUILD_DIR)/build/bin/$(_DISNEY_TARGET_PLATFORM)/$(_DISNEY_BUILD_TYPE)/morgana" "$(TARGET_DIR)/usr/bin/morgana"
 endef
@@ -81,8 +81,8 @@ endif
 
 define _DISNEY_TOOLING_INSTALL
     @echo "Installing shield_runtime"
-    cp -R "$(_DISNEY_BUILD_DIR)/shield_runtime" "$(TARGET_DIR)$(_DISNEY_DATA_DIR)"
-    cp -R "$(_DISNEY_BUILD_DIR)/build/shield_runtime/shield_agent_data/assets/dy_lib_tests" "$(TARGET_DIR)$(_DISNEY_DATA_DIR)/shield_runtime/shield_agent_data/assets"
+    rsync -a "$(_DISNEY_BUILD_DIR)/shield_runtime" "$(TARGET_DIR)$(_DISNEY_DATA_DIR)"
+    rsync -a "$(_DISNEY_BUILD_DIR)/build/shield_runtime/shield_agent_data/assets/dy_lib_tests" "$(TARGET_DIR)$(_DISNEY_DATA_DIR)/shield_runtime/shield_agent_data/assets"
     $(call _DISNEY_TOOLING_INSTALL_SHIELD_AGENT)
     $(call _DISNEY_TOOLING_INSTALL_SHIELD_EXTENSION)
 endef

--- a/package/disney/disney-tooling/disney-tooling.mk
+++ b/package/disney/disney-tooling/disney-tooling.mk
@@ -15,7 +15,7 @@ DISNEY_TOOLING_DEPENDENCIES = disney
 # A link is created from the shield-agent (this build dir) to the ADK build directory.
 # That way shield-agent and extension can be properly configured using configuration variables from the ADK
 # and a proper premake file can be selected. Then it is built using generated make files inside the ADK build directory.
-_DISNEY_BUILD_DIR = $(BUILD_DIR)/disney-$(DISNEY_VERSION)
+_DISNEY_BUILD_DIR = "$(BUILD_DIR)/disney-$(DISNEY_VERSION)"
 
 
 _DISNEY_TOOLING_CONFIGURE_FLAGS = --verbose \
@@ -29,7 +29,7 @@ _DISNEY_TOOLING_CONFIGURE_FLAGS += --player=$(_DISNEY_PLAYER) $(_DISNEY_CURL_HTT
 endif
 
 define DISNEY_TOOLING_CONFIGURE_CMDS
-    ln -sf $(@D)/shield-agent ${_DISNEY_BUILD_DIR}
+    ln -sf "$(@D)/shield-agent" "${_DISNEY_BUILD_DIR}"
     cd "$(_DISNEY_BUILD_DIR)" && \
 		CC="$(TARGET_CC)" CXX="$(TARGET_CXX)" GCC_PREFIX="$(TARGET_CROSS)" PLATFORM="$(_DISNEY_TARGET_PLATFORM)" \
     	ARCH="$(KERNEL_ARCH)" SSL_VERSION="$(DISNEY_LIBOPENSSL_SO_VERSION)" SYSINCLUDEDIR="$(STAGING_DIR)/usr/include" \

--- a/package/disney/disney-tooling/disney-tooling.mk
+++ b/package/disney/disney-tooling/disney-tooling.mk
@@ -13,10 +13,18 @@ DISNEY_TOOLING_DEPENDENCIES = disney
 
 _DISNEY_EXTRACT_DIR = $(BUILD_DIR)/disney-$(DISNEY_VERSION)
 
+ifeq ($(BR2_PACKAGE_DISNEY_PLAYER_UMA),y)
+_DISNEY_PLAYER = nve-shared
+_DISNEY_CURL_HTTP = --curl-http2
+DISNEY_TOOLING_DEPENDENCIES += disney-uma
+endif
+
 define DISNEY_TOOLING_CONFIGURE_CMDS
        ln -sf $(@D)/shield-agent ${_DISNEY_EXTRACT_DIR}
-       cd $(_DISNEY_EXTRACT_DIR) && CC="$(TARGET_CC)" CXX="$(TARGET_CXX)" GCC_PREFIX="$(TARGET_CROSS)" PLATFORM="$(_DISNEY_TARGET_PLATFORM)" ARCH="$(KERNEL_ARCH)" \
-          ./premake5 --verbose --file=shield-agent/premake5.lua --target=$(_DISNEY_TARGET_NAME) gmake2
+       cd $(_DISNEY_EXTRACT_DIR) && CC="$(TARGET_CC)" CXX="$(TARGET_CXX)" GCC_PREFIX="$(TARGET_CROSS)" PLATFORM="$(_DISNEY_TARGET_PLATFORM)" \
+          ARCH="$(KERNEL_ARCH)" SSL_VERSION="$(DISNEY_LIBOPENSSL_SO_VERSION)" SYSINCLUDEDIR="$(STAGING_DIR)/usr/include" \
+              SYSLIBDIR="$(STAGING_DIR)/usr/lib" \
+                 ./premake5 --verbose --file=shield-agent/premake5.lua --target=$(_DISNEY_TARGET_NAME) --player=$(_DISNEY_PLAYER) $(_DISNEY_CURL_HTTP) gmake2
 endef
 
 ifeq ($(BR2_PACKAGE_DISNEY_TOOLING_SHIELD_AGENT),y)

--- a/shield-agent
+++ b/shield-agent
@@ -1,1 +1,0 @@
-/home/lukasz/Desktop/builds/rpi3b+_vc4/build2/buildroot/output/build/disney-tooling-30f43c24c6f16394bef1192b5a48e252fec40fe2/shield-agent

--- a/shield-agent
+++ b/shield-agent
@@ -1,0 +1,1 @@
+/home/lukasz/Desktop/builds/rpi3b+_vc4/build2/buildroot/output/build/disney-tooling-30f43c24c6f16394bef1192b5a48e252fec40fe2/shield-agent


### PR DESCRIPTION
Allow for fetching ADK tooling from its repo and building it using  ADK sources (tooling is building from the same sources as the application itself). 
Currently, the tooling is extracted into its own directory, and a link for the shield-agent directory is created to the ADK directory. There is no simple way to obtain an ADK directory, so it is set as ```_DISNEY_EXTRACT_DIR = $(BUILD_DIR)/disney-$(DISNEY_VERSION)``` which will also work with overridden src_dir. 
Also, a separate menu is added to control which of the test features should be enabled.