### PR TITLE
[Tooling BUMP] On new tooling, do not manually copy dy_lib_tests

### DIFF
--- a/package/disney/disney-tooling/disney-tooling.mk
+++ b/package/disney/disney-tooling/disney-tooling.mk
@@ -82,7 +82,9 @@ endif
 define _DISNEY_TOOLING_INSTALL
     @echo "Installing shield_runtime"
     rsync -a "$(_DISNEY_BUILD_DIR)/shield_runtime" "$(TARGET_DIR)$(_DISNEY_DATA_DIR)"
-    rsync -a "$(_DISNEY_BUILD_DIR)/build/shield_runtime/shield_agent_data/assets/dy_lib_tests" "$(TARGET_DIR)$(_DISNEY_DATA_DIR)/shield_runtime/shield_agent_data/assets"
+    if [ -d "$(_DISNEY_BUILD_DIR)/build/shield_runtime/shield_agent_data/assets/dy_lib_tests" ]; then \
+        rsync -a "$(_DISNEY_BUILD_DIR)/build/shield_runtime/shield_agent_data/assets/dy_lib_tests" "$(TARGET_DIR)$(_DISNEY_DATA_DIR)/shield_runtime/shield_agent_data/assets"; \
+    fi
     $(call _DISNEY_TOOLING_INSTALL_SHIELD_AGENT)
     $(call _DISNEY_TOOLING_INSTALL_SHIELD_EXTENSION)
 endef


### PR DESCRIPTION
NOTE: When you want to build new tooling on the RPI, apply this patch: https://github.com/WebPlatformForEmbedded/meta-metrological-uma-patches/blob/development/2.1.1-bump/recipes-disney/disneyplus/files/disney-tooling/0001-Change-C-standard-to-build-adk-tooling-1.2.2.patch