### PR TITLE
[METROL-480] Fix for Netflix crash on trailer end.

### DIFF
--- a/package/netflix52/0002-netflix-trailer-crash.patch
+++ b/package/netflix52/0002-netflix-trailer-crash.patch
@@ -1,0 +1,13 @@
+diff --git a/netflix/src/nrd/Media/NrdpMediaSourceBuffer.cpp b/netflix/src/nrd/Media/NrdpMediaSourceBuffer.cpp
+index 97b237e5..c4466556 100644
+--- a/netflix/src/nrd/Media/NrdpMediaSourceBuffer.cpp
++++ b/netflix/src/nrd/Media/NrdpMediaSourceBuffer.cpp
+@@ -556,7 +556,7 @@ AseTimeStamp NrdpMediaSourceBuffer::flush(AseTimeStamp const& pts, AseTimeStamp
+            mediaTypeToString(mMediaType).c_str(),
+            mMediaTrackFragments[mPrimaryTrackId].front()->getFragmentStartTime().getValueInMs(),
+            mMediaTrackFragments[mPrimaryTrackId].front()->getFragmentEndTime().getValueInMs());
+-    return mMediaTrackFragments[mPrimaryTrackId].front()->getFragmentStartTime();
++    return  mMediaTrackFragments[mPrimaryTrackId].empty() ? AseTimeStamp::INFINITE : mMediaTrackFragments[mPrimaryTrackId].front()->getFragmentStartTime();
+ }
+ 
+ AseTimeStamp NrdpMediaSourceBuffer::provideBlock(AseBufferPtr pData, int32_t currentTimestampOffset, uint32_t currentTimestampOffsetTimescale)


### PR DESCRIPTION
There is a delay in Netflix Application calling
playerClose API. There is a thread which tries to
flush presented fragments from mMediaTrackFragments
and returns the PTS for the first element from the
list. Whenever there is a delay, it would delete
all the elements and tries to fetch the PTS from
the non existing element which results in the crash.

As a fix now we are checking if the list is empty
before trying to get the PTS from the front element.