### PR TITLE
Backport graceful shutdown patches for cobalt

### DIFF
--- a/package/cobalt/007-cobalt-add-graceful-shutdown-api.patch
+++ b/package/cobalt/007-cobalt-add-graceful-shutdown-api.patch
@@ -1,0 +1,74 @@
+From f72828eb81a67fb57293ac9d64352dd2fc39a5d2 Mon Sep 17 00:00:00 2001
+From: krp97 <k.plata@metrological.com>
+Date: Tue, 10 May 2022 11:00:55 +0000
+Subject: [PATCH] Backport graceful shutdown API
+
+This commit backports functionality from the following hash:
+	d6b24547c604b84ca9a5d16b054944c4521fce66,
+in order to avoid generating core dumps while quitting cobalt.
+---
+ src/third_party/starboard/wpe/shared/application_wpe.cc | 4 ++++
+ src/third_party/starboard/wpe/shared/application_wpe.h  | 1 +
+ src/third_party/starboard/wpe/shared/cobalt_api_wpe.cc  | 6 ++++++
+ src/third_party/starboard/wpe/shared/cobalt_api_wpe.h   | 1 +
+ 4 files changed, 12 insertions(+)
+
+diff --git a/src/third_party/starboard/wpe/shared/application_wpe.cc b/src/third_party/starboard/wpe/shared/application_wpe.cc
+index 9384cef69b..cc0827776b 100644
+--- a/src/third_party/starboard/wpe/shared/application_wpe.cc
++++ b/src/third_party/starboard/wpe/shared/application_wpe.cc
+@@ -173,6 +173,10 @@ bool Application::IsPreloadImmediate()
+   return true;
+ }
+ 
++void Application::Stop() {
++  SbSystemRequestStop(0);
++}
++
+ }  // namespace shared
+ }  // namespace wpe
+ }  // namespace starboard
+diff --git a/src/third_party/starboard/wpe/shared/application_wpe.h b/src/third_party/starboard/wpe/shared/application_wpe.h
+index 7034cd213c..11cb6537a6 100644
+--- a/src/third_party/starboard/wpe/shared/application_wpe.h
++++ b/src/third_party/starboard/wpe/shared/application_wpe.h
+@@ -50,6 +50,7 @@ class Application : public ::starboard::shared::starboard::QueueApplication {
+   void DeepLink(const char* link_data);
+   void Suspend();
+   void Resume();
++  void Stop();
+  protected:
+   // --- Application overrides ---
+   void Initialize() override;
+diff --git a/src/third_party/starboard/wpe/shared/cobalt_api_wpe.cc b/src/third_party/starboard/wpe/shared/cobalt_api_wpe.cc
+index 00c3a7afc5..bb50d13591 100644
+--- a/src/third_party/starboard/wpe/shared/cobalt_api_wpe.cc
++++ b/src/third_party/starboard/wpe/shared/cobalt_api_wpe.cc
+@@ -34,6 +34,12 @@ void Resume()
+     Application::Get()->Resume();
+ }
+ 
++void Stop()
++{
++    Application::WaitForInit();
++    Application::Get()->Stop();
++}
++
+ }  // namespace shared
+ }  // namespace wpe
+ }  // namespace starboard
+diff --git a/src/third_party/starboard/wpe/shared/cobalt_api_wpe.h b/src/third_party/starboard/wpe/shared/cobalt_api_wpe.h
+index 8097bb7cfc..4a52836eee 100644
+--- a/src/third_party/starboard/wpe/shared/cobalt_api_wpe.h
++++ b/src/third_party/starboard/wpe/shared/cobalt_api_wpe.h
+@@ -24,6 +24,7 @@ void SetURL(const char* link_data);
+ void DeepLink(const char* link_data);
+ void Resume();
+ void Suspend();
++void Stop();
+ 
+ }  // namespace shared
+ }  // namespace wpe
+-- 
+2.25.1
+

--- a/package/wpe/wpeframework-plugins/0037--Replace-SIGQUIT-with-API-call-to-teardown.patch
+++ b/package/wpe/wpeframework-plugins/0037--Replace-SIGQUIT-with-API-call-to-teardown.patch
@@ -1,0 +1,42 @@
+From df0052ba38e25ee56b09a6361995b86755d90f30 Mon Sep 17 00:00:00 2001
+From: krp97 <k.plata@metrological.com>
+Date: Tue, 10 May 2022 10:43:53 +0000
+Subject: [PATCH] Replace SIGQUIT with API call to teardown
+
+---
+ Cobalt/CobaltImplementation.cpp | 12 +-----------
+ 1 file changed, 1 insertion(+), 11 deletions(-)
+
+diff --git a/Cobalt/CobaltImplementation.cpp b/Cobalt/CobaltImplementation.cpp
+index d0943424..dd56c55c 100644
+--- a/Cobalt/CobaltImplementation.cpp
++++ b/Cobalt/CobaltImplementation.cpp
+@@ -170,7 +170,7 @@ private:
+         virtual ~CobaltWindow()
+         {
+             Block();
+-            Signal(SIGQUIT);
++            third_party::starboard::wpe::shared::Stop();
+             Wait(Thread::BLOCKED | Thread::STOPPED | Thread::STOPPING, Core::infinite);
+         }
+ 
+@@ -291,16 +291,6 @@ private:
+         string Url() const { return _url; }
+ 
+     private:
+-        bool Initialize() override
+-        {
+-            sigset_t mask;
+-            sigemptyset(&mask);
+-            sigaddset(&mask, SIGQUIT);
+-            sigaddset(&mask, SIGUSR1);
+-            sigaddset(&mask, SIGCONT);
+-            pthread_sigmask(SIG_UNBLOCK, &mask, nullptr);
+-            return (true);
+-        }
+         uint32_t Worker() override
+         {
+             const std::string cmdURL = "--url=" + _url;
+-- 
+2.25.1
+


### PR DESCRIPTION
This PR backports the following changes:
- https://github.com/Metrological/cobalt/commit/d6b24547c604b84ca9a5d16b054944c4521fce66
- https://github.com/rdkcentral/ThunderNanoServices/commit/b4826326b876b9f087dee3a629bc3a32bc870056

in order to remove SIGQUIT, as the way of exiting cobalt.