### PR TITLE
package/libcurl: fix crypto backend selection

### DIFF
--- a/package/libcurl/libcurl.mk
+++ b/package/libcurl/libcurl.mk
@@ -38,6 +38,10 @@ endif
 
 LIBCURL_CONFIG_SCRIPTS = curl-config
 
+ifeq ($(BR2_PACKAGE_LIBCURL_TLS_NONE),y)
+LIBCURL_CONF_OPTS += --without-ssl
+endif
+
 ifeq ($(BR2_PACKAGE_LIBCURL_OPENSSL),y)
 LIBCURL_DEPENDENCIES += openssl
 # configure adds the cross openssl dir to LD_LIBRARY_PATH which screws up
@@ -45,10 +49,10 @@ LIBCURL_DEPENDENCIES += openssl
 # Fix it by setting LD_LIBRARY_PATH to something sensible so those libs
 # are found first.
 LIBCURL_CONF_ENV += LD_LIBRARY_PATH=$(if $(LD_LIBRARY_PATH),$(LD_LIBRARY_PATH):)/lib:/usr/lib
-LIBCURL_CONF_OPTS += --with-ssl=$(STAGING_DIR)/usr \
+LIBCURL_CONF_OPTS += --with-openssl=$(STAGING_DIR)/usr \
 	--with-ca-path=/etc/ssl/certs
 else
-LIBCURL_CONF_OPTS += --without-ssl
+LIBCURL_CONF_OPTS += --without-openssl
 endif
 
 ifeq ($(BR2_PACKAGE_LIBCURL_GNUTLS),y)


### PR DESCRIPTION
This imports commit [f39810149ebe4041c77ca02560c58c93328de723](https://git.busybox.net/buildroot/commit/?id=f39810149ebe4041c77ca02560c58c93328de723) from upstream Buildroot.

```
Since version 7.77 --with-ssl that used to select OpenSSL renamed to --with-openssl. --without-ssl changed to mean no crypto backend.

Only in version 7.86 setting both --without-ssl and some other crypto parameter became a hard configure error.

Update OpenSSL selection parameter, and add --without-ssl explicitly for the case of no selected crypto backend.

Fixes:
http://autobuild.buildroot.net/results/05e9cb71619e640849c27b2984d0df671a9f86c5/ http://autobuild.buildroot.net/results/5a4a905de2a232a38916f03278d0a3cbd8a29711/ http://autobuild.buildroot.net/results/4432314aa13d4acc8fce27f79177f82298ae0626/

Cc: Matt Weber <matthew.weber@collins.com>
Signed-off-by: Baruch Siach <baruch@tkos.co.il>
Signed-off-by: Yann E. MORIN <yann.morin.1998@free.fr>