### PR TITLE
VIP5202: Fix for missing UHD badge

### DIFF
--- a/package/amazon-backend/amazon-backend.mk
+++ b/package/amazon-backend/amazon-backend.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-AMAZON_BACKEND_VERSION = 6916e98947a38c1800f9906e6d07e1429cd621b1
+AMAZON_BACKEND_VERSION = 5b885171dff065ba100c652e89f89fdef60e7af2
 AMAZON_BACKEND_SITE = git@github.com:Metrological/amazon-backend.git
 AMAZON_BACKEND_SITE_METHOD = git
 AMAZON_BACKEND_DEPENDENCIES =

--- a/package/libamazon/libamazon.mk
+++ b/package/libamazon/libamazon.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-LIBAMAZON_VERSION = 750c0371252d41c5c4e765d0fe4b427f2eee4c20
+LIBAMAZON_VERSION = a3793513e0456ecbdf334ae7bb5a973ef5b6031a
 LIBAMAZON_SITE_METHOD = git
 LIBAMAZON_SITE = git@github.com:Metrological/libamazon.git
 LIBAMAZON_LICENSE = PROPRIETARY


### PR DESCRIPTION
UHD capability badge was missing on ACN box. Also it was not able
to play 4K content. Problem was related to Broadcom API, which
returned invalid preferredWith/preferredHeight in pixels. Thus we
decided to read that values directly from EDID data omitting this
API.