### PR TITLE
Set default westeros resolution to 1080p

### DIFF
--- a/package/westeros/0001-Set-default-resolution-to-1080.patch
+++ b/package/westeros/0001-Set-default-resolution-to-1080.patch
@@ -1,0 +1,71 @@
+From 5e552082c4b3a2bd64be68e6a7dfc8a7f6cc2c52 Mon Sep 17 00:00:00 2001
+From: wouterlucas <wouter@wouterlucas.com>
+Date: Thu, 25 Jul 2019 16:27:40 -0700
+Subject: [PATCH] Set default resolution to 1080
+
+Signed-off-by: wouterlucas <wouter@wouterlucas.com>
+
+---
+ westeros-compositor.cpp | 8 ++++----
+ westeros-main.cpp       | 6 +++---
+ westeros-render.cpp     | 4 ++--
+ 3 files changed, 9 insertions(+), 9 deletions(-)
+
+diff --git a/westeros-compositor.cpp b/westeros-compositor.cpp
+index 3f051d8..195a315 100644
+--- a/westeros-compositor.cpp
++++ b/westeros-compositor.cpp
+@@ -67,10 +67,10 @@
+ #define MAX_NESTED_NAME_LEN (32)
+ 
+ #define DEFAULT_FRAME_RATE (60)
+-#define DEFAULT_OUTPUT_WIDTH (1280)
+-#define DEFAULT_OUTPUT_HEIGHT (720)
+-#define DEFAULT_NESTED_WIDTH (1280)
+-#define DEFAULT_NESTED_HEIGHT (720)
++#define DEFAULT_OUTPUT_WIDTH (1920)
++#define DEFAULT_OUTPUT_HEIGHT (1080)
++#define DEFAULT_NESTED_WIDTH (1920)
++#define DEFAULT_NESTED_HEIGHT (1080)
+ 
+ #define DEFAULT_KEY_REPEAT_DELAY (1000)
+ #define DEFAULT_KEY_REPEAT_RATE  (5)
+diff --git a/westeros-main.cpp b/westeros-main.cpp
+index e4e73b7..523cbc7 100644
+--- a/westeros-main.cpp
++++ b/westeros-main.cpp
+@@ -1321,8 +1321,8 @@ AppCtx* initApp()
+    appCtx= (AppCtx*)calloc( 1, sizeof(AppCtx) );
+    if ( appCtx )
+    {
+-      appCtx->windowWidth= 1280;
+-      appCtx->windowHeight= 720;
++      appCtx->windowWidth= 1920;
++      appCtx->windowHeight= 1080;
+ 
+       #if defined (WESTEROS_PLATFORM_EMBEDDED)
+       appCtx->inputCtx= (InputCtx*)calloc( 1, sizeof(InputCtx) );
+@@ -1334,7 +1334,7 @@ AppCtx* initApp()
+       glutInit(&argc,argv);
+       glutInitDisplayMode(GLUT_DOUBLE | GLUT_RGBA );
+       glutInitWindowPosition(0,0);
+-      glutInitWindowSize(1280, 720);
++      glutInitWindowSize(1920, 1080);
+       
+       sprintf( appCtx->title, "Westeros-%d", getpid() );
+       appCtx->glutWindowId= glutCreateWindow(appCtx->title);
+diff --git a/westeros-render.cpp b/westeros-render.cpp
+index f5d5d55..6b2cc46 100644
+--- a/westeros-render.cpp
++++ b/westeros-render.cpp
+@@ -27,8 +27,8 @@
+ #include "westeros-nested.h"
+ #include "westeros-render.h"
+ 
+-#define DEFAULT_OUTPUT_WIDTH (1280)
+-#define DEFAULT_OUTPUT_HEIGHT (720)
++#define DEFAULT_OUTPUT_WIDTH (1920)
++#define DEFAULT_OUTPUT_HEIGHT (1080)
+ 
+ #define WESTEROS_UNUSED(x) ((void)(x))
+ 


### PR DESCRIPTION
Cherry-pick [patch from meta-wpe ](https://github.com/WebPlatformForEmbedded/meta-wpe/blob/main/recipes-graphics/westeros/files/0003-Set-default-resolution-to-1080.patch).

With WPE 2.46 on Sagemcom STB, we observed that although the WebKitBrowser was being rendered full-screen at 1080p, video playback via hole-punch with `westerossink` was only rendered to a 720p area. This patch fixes this.

Before:
![image](https://github.com/user-attachments/assets/dbe197e8-cd91-49d5-a398-22602da62d28)

After:
![image](https://github.com/user-attachments/assets/3d6e343f-bbd0-4c4f-b990-9e43897ed4b1)

