### PR TITLE
wpebackend-rdk: use version R4.4.1 unless the essos backend is used

### DIFF
--- a/package/wpe/wpebackend-rdk/wpebackend-rdk.mk
+++ b/package/wpe/wpebackend-rdk/wpebackend-rdk.mk
@@ -4,7 +4,11 @@
 #
 ################################################################################
 
-WPEBACKEND_RDK_VERSION = 31337f13eed21e16766129050933f5e1aa655cf4 #R4.4.1
+ifeq ($(BR2_PACKAGE_WPEBACKEND_RDK_BACK_ESSOS),y)
+WPEBACKEND_RDK_VERSION = 31337f13eed21e16766129050933f5e1aa655cf4
+else
+WPEBACKEND_RDK_VERSION = R4.4.1
+endif
 WPEBACKEND_RDK_SITE = $(call github,WebPlatformForEmbedded,WPEBackend-rdk,$(WPEBACKEND_RDK_VERSION))
 WPEBACKEND_RDK_INSTALL_STAGING = YES
 WPEBACKEND_RDK_DEPENDENCIES = wpebackend libglib2


### PR DESCRIPTION
Builds like the raspberrypi3 use the wpeframework backend, and since we have wpeframework-clientlibraries R4.4.1, the version of wpebackend-rdk must match or we get build errors from changes to Client.h due to the change in the header:
`void AddRef() const` -> `uint32_t AddRef() const`