### PR TITLE
gst-omx: remove encoding bits from 0005-Manual-revert-of-0603e44-omxvideodec-enc-delay-alloc.patch

### DIFF
--- a/package/gstreamer1/gst-omx/1.18.6/0005-Manual-revert-of-0603e44-omxvideodec-enc-delay-alloc.patch
+++ b/package/gstreamer1/gst-omx/1.18.6/0005-Manual-revert-of-0603e44-omxvideodec-enc-delay-alloc.patch
@@ -9,16 +9,17 @@ and causes lots of horrible troubles in general.
 
 This revert also includes some of the changes from
 7f49493 omxvideoenc/dec: fix handling of component enabling failing
-ported to their right place.
+ported to their right place. We revert only the decoding part,
+because reverting encoding part leads to a crash when encoding
+with omxvideoenc.
 
 This reversion may cause merge conflicts in the future. They're avoidable
-in general if the changes done to the gst_omx_video_enc_handle_frame()
-code block which calls gst_omx_video_enc_enable() are ported to the reverted
-code block in gst_omx_video_enc_set_format().
+in general if the changes done to the gst_omx_video_dec_handle_frame()
+code block which calls gst_omx_video_dec_enable() are ported to the reverted
+code block in gst_omx_video_dec_set_format().
 ---
  omx/gstomxvideodec.c | 33 +++++++++++++--------------------
- omx/gstomxvideoenc.c | 33 +++++++++++++--------------------
- 2 files changed, 26 insertions(+), 40 deletions(-)
+ 1 file changed, 13 insertions(+), 20 deletions(-)
 
 diff --git a/omx/gstomxvideodec.c b/omx/gstomxvideodec.c
 index 0a32b8c..2e575c6 100644
@@ -27,7 +28,7 @@ index 0a32b8c..2e575c6 100644
 @@ -2880,6 +2880,19 @@ gst_omx_video_dec_set_format (GstVideoDecoder * decoder,
    gst_omx_video_dec_set_latency (self);
  #endif
- 
+
 +  if (!gst_omx_video_dec_enable (self, NULL)) {
 +    /* Report the OMX error, if any */
 +    if (gst_omx_component_get_last_error (self->dec) != OMX_ErrorNone)
@@ -47,7 +48,7 @@ index 0a32b8c..2e575c6 100644
 @@ -3001,11 +3014,6 @@ gst_omx_video_dec_handle_frame (GstVideoDecoder * decoder,
        return GST_FLOW_OK;
      }
- 
+
 -    if (gst_omx_port_is_flushing (self->dec_out_port) || self->dec_out_port && self->dec_out_port->buffers == NULL) {
 -      if (!gst_omx_video_dec_enable (self, frame->input_buffer))
 -        goto enable_error;
@@ -59,7 +60,7 @@ index 0a32b8c..2e575c6 100644
 @@ -3263,21 +3271,6 @@ map_failed:
      return GST_FLOW_ERROR;
    }
- 
+
 -enable_error:
 -  {
 -    /* Report the OMX error, if any */
@@ -78,64 +79,6 @@ index 0a32b8c..2e575c6 100644
  component_error:
    {
      gst_video_codec_frame_unref (frame);
-diff --git a/omx/gstomxvideoenc.c b/omx/gstomxvideoenc.c
-index 6dbfb41..1cd45fd 100644
---- a/omx/gstomxvideoenc.c
-+++ b/omx/gstomxvideoenc.c
-@@ -2639,6 +2639,19 @@ gst_omx_video_enc_set_format (GstVideoEncoder * encoder,
-   gst_omx_video_enc_set_latency (self);
- #endif
- 
-+  if (!gst_omx_video_enc_enable (self, NULL)) {
-+    /* Report the OMX error, if any */
-+    if (gst_omx_component_get_last_error (self->enc) != OMX_ErrorNone)
-+      GST_ELEMENT_ERROR (self, LIBRARY, FAILED, (NULL),
-+          ("Failed to enable OMX encoder: %s (0x%08x)",
-+              gst_omx_component_get_last_error_string (self->enc),
-+              gst_omx_component_get_last_error (self->enc)));
-+    else
-+      GST_ELEMENT_ERROR (self, LIBRARY, FAILED, (NULL),
-+          ("Failed to enable OMX encoder"));
-+    return FALSE;
-+  }
-+
-   self->downstream_flow_ret = GST_FLOW_OK;
-   return TRUE;
- }
-@@ -3043,11 +3056,6 @@ gst_omx_video_enc_handle_frame (GstVideoEncoder * encoder,
-   }
- 
-   if (!self->started) {
--    if (gst_omx_port_is_flushing (self->enc_out_port)) {
--      if (!gst_omx_video_enc_enable (self, frame->input_buffer))
--        goto enable_error;
--    }
--
-     GST_DEBUG_OBJECT (self, "Starting task");
-     gst_pad_start_task (GST_VIDEO_ENCODER_SRC_PAD (self),
-         (GstTaskFunction) gst_omx_video_enc_loop, self, NULL);
-@@ -3263,21 +3271,6 @@ flow_error:
-     return self->downstream_flow_ret;
-   }
- 
--enable_error:
--  {
--    /* Report the OMX error, if any */
--    if (gst_omx_component_get_last_error (self->enc) != OMX_ErrorNone)
--      GST_ELEMENT_ERROR (self, LIBRARY, FAILED, (NULL),
--          ("Failed to enable OMX encoder: %s (0x%08x)",
--              gst_omx_component_get_last_error_string (self->enc),
--              gst_omx_component_get_last_error (self->enc)));
--    else
--      GST_ELEMENT_ERROR (self, LIBRARY, FAILED, (NULL),
--          ("Failed to enable OMX encoder"));
--    gst_video_codec_frame_unref (frame);
--    return GST_FLOW_ERROR;
--  }
--
- component_error:
-   {
-     GST_ELEMENT_ERROR (self, LIBRARY, FAILED, (NULL),
--- 
+--
 2.34.1
 


### PR DESCRIPTION
Reverting the encoding bits, we get a crash with the following pipeline: 
```
$ gst-launch-1.0 videotestsrc ! omxh264enc ! fakesink
```

Therefore, don't apply the encoder bits, in order to have video encoding correctly working when doing hardware-accelerated video encoding in WebRTC in WPE