### PR TITLE
Fix WebKit 100% CPU usage in rpi3

### DIFF
--- a/package/glibc/2.30-20-g50f20fe506abb8853641006a7b90a81af21d7b91/0002-vfscanf_internal-fix-aliasing-violation-bug-26690.patch
+++ b/package/glibc/2.30-20-g50f20fe506abb8853641006a7b90a81af21d7b91/0002-vfscanf_internal-fix-aliasing-violation-bug-26690.patch
@@ -1,0 +1,91 @@
+From c0e9ddf59e73e21afe15fca4e94cf7b4b7359bf2 Mon Sep 17 00:00:00 2001
+Message-ID: <c0e9ddf59e73e21afe15fca4e94cf7b4b7359bf2.1755776786.git.aboya@igalia.com>
+From: Andreas Schwab <schwab@suse.de>
+Date: Thu, 1 Oct 2020 13:59:13 +0200
+Subject: [PATCH] __vfscanf_internal: fix aliasing violation (bug 26690)
+
+As noted in <https://gcc.gnu.org/bugzilla/show_bug.cgi?id=97264>, the cast
+in the call to the read_int function is an aliasing violation.  Change the
+type of local variable f to a pointer to unsigned, which allows to
+eliminate most casts while only adding three new ones.
+---
+ stdio-common/vfscanf-internal.c | 22 +++++++++++-----------
+ 1 file changed, 11 insertions(+), 11 deletions(-)
+
+diff --git a/stdio-common/vfscanf-internal.c b/stdio-common/vfscanf-internal.c
+index 95b46dcbeb..3a323547f9 100644
+--- a/stdio-common/vfscanf-internal.c
++++ b/stdio-common/vfscanf-internal.c
+@@ -277,7 +277,7 @@ __vfscanf_internal (FILE *s, const char *format, va_list argptr,
+ #endif
+ {
+   va_list arg;
+-  const CHAR_T *f = format;
++  const UCHAR_T *f = (const UCHAR_T *) format;
+   UCHAR_T fc;	/* Current character of the format.  */
+   WINT_T done = 0;	/* Assignments done.  */
+   size_t read_in = 0;	/* Chars read in.  */
+@@ -415,10 +415,11 @@ __vfscanf_internal (FILE *s, const char *format, va_list argptr,
+ #endif
+ 
+ #ifndef COMPILE_WSCANF
+-      if (!isascii ((unsigned char) *f))
++      if (!isascii (*f))
+ 	{
+ 	  /* Non-ASCII, may be a multibyte.  */
+-	  int len = __mbrlen (f, strlen (f), &state);
++	  int len = __mbrlen ((const char *) f, strlen ((const char *) f),
++			      &state);
+ 	  if (len > 0)
+ 	    {
+ 	      do
+@@ -426,7 +427,7 @@ __vfscanf_internal (FILE *s, const char *format, va_list argptr,
+ 		  c = inchar ();
+ 		  if (__glibc_unlikely (c == EOF))
+ 		    input_error ();
+-		  else if (c != (unsigned char) *f++)
++		  else if (c != *f++)
+ 		    {
+ 		      ungetc_not_eof (c, s);
+ 		      conv_error ();
+@@ -484,9 +485,9 @@ __vfscanf_internal (FILE *s, const char *format, va_list argptr,
+       char_buffer_rewind (&charbuf);
+ 
+       /* Check for a positional parameter specification.  */
+-      if (ISDIGIT ((UCHAR_T) *f))
++      if (ISDIGIT (*f))
+ 	{
+-	  argpos = read_int ((const UCHAR_T **) &f);
++	  argpos = read_int (&f);
+ 	  if (*f == L_('$'))
+ 	    ++f;
+ 	  else
+@@ -521,8 +522,8 @@ __vfscanf_internal (FILE *s, const char *format, va_list argptr,
+ 
+       /* Find the maximum field width.  */
+       width = 0;
+-      if (ISDIGIT ((UCHAR_T) *f))
+-	width = read_int ((const UCHAR_T **) &f);
++      if (ISDIGIT (*f))
++	width = read_int (&f);
+     got_width:
+       if (width == 0)
+ 	width = -1;
+@@ -2522,12 +2523,11 @@ __vfscanf_internal (FILE *s, const char *format, va_list argptr,
+ 	    }
+ 
+ 	  while ((fc = *f++) != '\0' && fc != ']')
+-	    if (fc == '-' && *f != '\0' && *f != ']'
+-		&& (unsigned char) f[-2] <= (unsigned char) *f)
++	    if (fc == '-' && *f != '\0' && *f != ']' && f[-2] <= *f)
+ 	      {
+ 		/* Add all characters from the one before the '-'
+ 		   up to (but not including) the next format char.  */
+-		for (fc = (unsigned char) f[-2]; fc < (unsigned char) *f; ++fc)
++		for (fc = f[-2]; fc < *f; ++fc)
+ 		  ((char *)charbuf.scratch.data)[fc] = 1;
+ 	      }
+ 	    else
+-- 
+2.50.1
+


### PR DESCRIPTION
Backport of https://github.com/bminor/glibc/commit/c0e9ddf59e73e21afe15fca4e94cf7b4b7359bf2

glibc 2.30 has an aliasing bug in its scanf implementation, leading to undefined behavior. In a rpi3 with gcc 11.2.0 this causes scanf to return prematurely in simple usages that  include a width modifier.

Here is a minimal repro:
`/tmp/test-scanf.c`:
```
static char buf[100];
int main(int argc, char** argv) {
  if (argc < 2) return 2;
  FILE* fp = fopen(argv[1], "r");
  if (!fp) return 1;
  int ret = fscanf(fp, "%9s", buf);
  if (ret != 1) {
    printf("scanf didn't consume enough! returned %d\n", ret);
    return 1;
  }
  printf("Read: %s\n", buf);
}
```

In affected glibc versions, fscanf will always return 0. This caused the MemoryPressureMonitor code in WebKit to endlessly loop like this:

```
       │     while (!feof(memInfoFile)) {
  5.75 │180:┌─→mov          r0, sl
       │    │→ bl           feof@plt
 17.67 │    │  cmp          r0, #0
       │    │↓ bne          594
       │    │char token[MEMINFO_TOKEN_BUFFER_SIZE + 1] = { 0 };
  6.15 │    │  vmov.i32     q8, #0  @ 0x00000000
  6.08 │    │  ldr          r3, [fp, #-192] @ 0xffffff40
  5.14 │    │  str          r0, [fp, #-144] @ 0xffffff70
       │    │if (fscanf(memInfoFile, "%" STRINGIFY(MEMINFO_TOKEN_BUFFER_SIZE) "s%zukB", token, &amount) != 2)
       │    │  mov          r2, r6
  4.96 │    │  mov          r1, r5
       │    │  mov          r0, sl
       │    │char token[MEMINFO_TOKEN_BUFFER_SIZE + 1] = { 0 };
  5.98 │    │  vstr         d16, [r7, #32]
  6.61 │    │  vst1.8       {d16-d17}, [r7]
 11.91 │    │  vstr         d16, [r7, #16]
  5.52 │    │  vstr         d16, [r7, #24]
  5.67 │    │  vst1.8       {d16}, [r3]
       │    │if (fscanf(memInfoFile, "%" STRINGIFY(MEMINFO_TOKEN_BUFFER_SIZE) "s%zukB", token, &amount) != 2)
       │    │  mov          r3, r9
 11.83 │    │→ bl           __isoc99_fscanf@plt
  6.75 │    │  cmp          r0, #2
       │    └──bne          180
```