### PR TITLE
Fix flaky DHCP in non-Thunder builds in rpi3

### DIFF
--- a/package/busybox/0004-Do-more-DISCOVER-retries.patch
+++ b/package/busybox/0004-Do-more-DISCOVER-retries.patch
@@ -1,0 +1,25 @@
+From 35b5e8804c8412546dd6a42c7d8979b82ba3ceec Mon Sep 17 00:00:00 2001
+From: Alicia Boya Garcia <aboya@igalia.com>
+Date: Tue, 15 Jul 2025 09:46:45 +0000
+Subject: [PATCH] Do more DISCOVER retries
+
+---
+ networking/udhcp/dhcpc.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/networking/udhcp/dhcpc.c b/networking/udhcp/dhcpc.c
+index 739870b..e501d42 100644
+--- a/networking/udhcp/dhcpc.c
++++ b/networking/udhcp/dhcpc.c
+@@ -1250,7 +1250,7 @@ int udhcpc_main(int argc UNUSED_PARAM, char **argv)
+ 	llist_t *list_x = NULL;
+ 	int tryagain_timeout = 20;
+ 	int discover_timeout = 3;
+-	int discover_retries = 3;
++	int discover_retries = 6;
+ 	uint32_t server_addr = server_addr; /* for compiler */
+ 	uint32_t requested_ip = 0;
+ 	uint32_t xid = xid; /* for compiler */
+-- 
+2.43.0
+


### PR DESCRIPTION
If your DHCP server is dnsmasq-based, you're not building Thunder and you're using a rpi3, there is a good chance half the time the rpi boots without an IP address.

This is because:
* udhcp sends 3 DISCOVER, waiting 3 seconds for a response in each case.
* The NIC of the rpi3 usually takes slightly above 6 seconds from `ifconfig eth0 up` to being functional enough to send packets, so the first two DISCOVER packets never reach the network.
* dnsmasq will do a 3 second long ping of an IP address before assigning it to a lease, unless its has done this recently and has it cached. If this happens on the last DISCOVER, by the time the rpi3 gets the OFFER packet, udhcp has already given up.

Once identified the problem, a simple fix is trivial: patch udhcp to send more DISCOVER packets.