### PR TITLE
[gst1-plugins-bad][mss] unref protection data only if it was allocated

### DIFF
--- a/package/gstreamer1/gst1-plugins-bad/1.16.2/0010-mssdemux-return-initialization-data-decoded-from-bas.patch
+++ b/package/gstreamer1/gst1-plugins-bad/1.16.2/0010-mssdemux-return-initialization-data-decoded-from-bas.patch
@@ -121,12 +121,13 @@ index 35d79837b..4c3465c13 100644
        xmlFree (system_id_attribute);
        break;
      }
-@@ -606,7 +610,7 @@ gst_mss_manifest_free (GstMssManifest * manifest)
+@@ -606,7 +610,8 @@ gst_mss_manifest_free (GstMssManifest * manifest)
  
    if (manifest->protection_system_id != NULL)
      g_string_free (manifest->protection_system_id, TRUE);
 -  xmlFree (manifest->protection_data);
-+  gst_buffer_unref (manifest->protection_data);
++  if (manifest->protection_data)
++    gst_buffer_unref (manifest->protection_data);
  
    xmlFreeDoc (manifest->xml);
    g_free (manifest);

--- a/package/gstreamer1/gst1-plugins-bad/1.18.6/0010-mssdemux-return-initialization-data-decoded-from-bas.patch
+++ b/package/gstreamer1/gst1-plugins-bad/1.18.6/0010-mssdemux-return-initialization-data-decoded-from-bas.patch
@@ -122,12 +122,13 @@ index 997d6fb59..90c02e637 100644
        xmlFree (system_id_attribute);
        break;
      }
-@@ -622,7 +626,7 @@ gst_mss_manifest_free (GstMssManifest * manifest)
+@@ -622,7 +626,8 @@ gst_mss_manifest_free (GstMssManifest * manifest)
  
    if (manifest->protection_system_id != NULL)
      g_string_free (manifest->protection_system_id, TRUE);
 -  xmlFree (manifest->protection_data);
-+  gst_buffer_unref (manifest->protection_data);
++  if (manifest->protection_data)
++    gst_buffer_unref (manifest->protection_data);
  
    xmlFreeDoc (manifest->xml);
    g_free (manifest);


### PR DESCRIPTION
gst_buffer_unref() calls g_mini_object_unref(), which in version 1.18.6 causes crash if object is NULL. In upstream there is early return in that case.